### PR TITLE
Feature/conviva custom events

### DIFF
--- a/.changeset/tough-hornets-sneeze.md
+++ b/.changeset/tough-hornets-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@theoplayer/conviva-connector-web": patch
+---
+
+Added functionality to listen for external ad events using the `convivaAdEventsExtension` property.

--- a/conviva/package.json
+++ b/conviva/package.json
@@ -34,11 +34,11 @@
     "package.json"
   ],
   "dependencies": {
-    "@convivainc/conviva-js-coresdk": "^4.6.1"
+    "@convivainc/conviva-js-coresdk": "^4.7.4"
   },
   "peerDependencies": {
-    "theoplayer": "^5.0.0 || ^6.0.0",
-    "@theoplayer/yospace-connector-web": "^2.1.0"
+    "@theoplayer/yospace-connector-web": "^2.1.0",
+    "theoplayer": "^5.0.0 || ^6.0.0"
   },
   "peerDependenciesMeta": {
     "@theoplayer/yospace-connector-web": {

--- a/conviva/package.json
+++ b/conviva/package.json
@@ -38,7 +38,7 @@
   },
   "peerDependencies": {
     "@theoplayer/yospace-connector-web": "^2.1.0",
-    "theoplayer": "^5.0.0 || ^6.0.0"
+    "theoplayer": "^5.0.0 || ^6.0.0 || ^7.0.0"
   },
   "peerDependenciesMeta": {
     "@theoplayer/yospace-connector-web": {

--- a/conviva/src/integration/ConvivaConnector.ts
+++ b/conviva/src/integration/ConvivaConnector.ts
@@ -43,6 +43,15 @@ export class ConvivaConnector {
     }
 
     /**
+     * Reports a custom event to the current Conviva session.
+     * @param eventType the type of the custom event.
+     * @param eventDetail an optional object containing event details.
+     */
+    reportPlaybackEvent(eventType: string, eventDetail?: object): void {
+        this.convivaHandler.reportPlaybackEvent(eventType, eventDetail);
+    }
+
+    /**
      * Explicitly stop the current session and start a new one.
      *
      * This can be used to manually mark the start of a new session during a live stream,

--- a/conviva/src/integration/ConvivaHandler.ts
+++ b/conviva/src/integration/ConvivaHandler.ts
@@ -62,14 +62,12 @@ export class ConvivaHandler {
 
         this.convivaAdAnalytics = Analytics.buildAdAnalytics(this.convivaVideoAnalytics);
 
-        if (this.player.ads !== undefined) {
-            this.adReporter = new CsaiAdReporter(
-                this.player,
-                this.convivaVideoAnalytics,
-                this.convivaAdAnalytics,
-                () => this.customMetadata
-            );
-        }
+        this.adReporter = new CsaiAdReporter(
+            this.player,
+            this.convivaVideoAnalytics,
+            this.convivaAdAnalytics,
+            () => this.customMetadata
+        );
 
         if (this.player.verizonMedia !== undefined) {
             this.verizonAdReporter = new VerizonAdReporter(

--- a/conviva/src/integration/ConvivaHandler.ts
+++ b/conviva/src/integration/ConvivaHandler.ts
@@ -121,6 +121,10 @@ export class ConvivaHandler {
         this.releaseSession();
     }
 
+    reportPlaybackEvent(eventType: string, eventDetail?: object): void {
+        this.convivaVideoAnalytics?.reportPlaybackEvent(eventType, eventDetail);
+    }
+
     stopAndStartNewSession(metadata: ConvivaMetadata): void {
         this.maybeReportPlaybackEnded();
         this.maybeReportPlaybackRequested();

--- a/conviva/src/integration/ConvivaHandler.ts
+++ b/conviva/src/integration/ConvivaHandler.ts
@@ -10,7 +10,7 @@ import {
     collectPlayerInfo,
     flattenAndStringifyObject
 } from '../utils/Utils';
-import { CsaiAdReporter } from './ads/CsaiAdReporter';
+import { AdReporter } from './ads/AdReporter';
 import { YospaceAdReporter } from './ads/YospaceAdReporter';
 import { VerizonAdReporter } from './ads/VerizonAdReporter';
 
@@ -29,7 +29,7 @@ export class ConvivaHandler {
     private convivaVideoAnalytics: VideoAnalytics | undefined;
     private convivaAdAnalytics: AdAnalytics | undefined;
 
-    private adReporter: CsaiAdReporter | undefined;
+    private adReporter: AdReporter | undefined;
     private yospaceAdReporter: YospaceAdReporter | undefined;
     private verizonAdReporter: VerizonAdReporter | undefined;
 
@@ -62,7 +62,7 @@ export class ConvivaHandler {
 
         this.convivaAdAnalytics = Analytics.buildAdAnalytics(this.convivaVideoAnalytics);
 
-        this.adReporter = new CsaiAdReporter(
+        this.adReporter = new AdReporter(
             this.player,
             this.convivaVideoAnalytics,
             this.convivaAdAnalytics,

--- a/conviva/src/integration/ads/AdReporter.ts
+++ b/conviva/src/integration/ads/AdReporter.ts
@@ -124,7 +124,7 @@ export class AdReporter {
     private addEventListeners(): void {
         this.player.addEventListener('playing', this.onPlaying);
         this.player.addEventListener('pause', this.onPause);
-        [this.player.ads, this.player.ads?.convivaAdEventsExtension].forEach((dispatcher)=> {
+        [this.player.ads, this.player.ads?.convivaAdEventsExtension].forEach((dispatcher) => {
             dispatcher?.addEventListener('adbreakbegin', this.onAdBreakBegin);
             dispatcher?.addEventListener('adbreakend', this.onAdBreakEnd);
             dispatcher?.addEventListener('adbegin', this.onAdBegin);
@@ -138,7 +138,7 @@ export class AdReporter {
     private removeEventListeners(): void {
         this.player.removeEventListener('playing', this.onPlaying);
         this.player.removeEventListener('pause', this.onPause);
-        [this.player.ads, this.player.ads?.convivaAdEventsExtension].forEach((dispatcher)=> {
+        [this.player.ads, this.player.ads?.convivaAdEventsExtension].forEach((dispatcher) => {
             dispatcher?.removeEventListener('adbreakbegin', this.onAdBreakBegin);
             dispatcher?.removeEventListener('adbreakend', this.onAdBreakEnd);
             dispatcher?.removeEventListener('adbegin', this.onAdBegin);

--- a/conviva/src/integration/ads/AdReporter.ts
+++ b/conviva/src/integration/ads/AdReporter.ts
@@ -2,7 +2,7 @@ import { Ad, AdBreak, ChromelessPlayer, GoogleImaAd } from 'theoplayer';
 import { AdAnalytics, Constants, ConvivaMetadata, VideoAnalytics } from '@convivainc/conviva-js-coresdk';
 import { calculateAdType, calculateCurrentAdBreakInfo, collectAdMetadata, collectPlayerInfo } from '../../utils/Utils';
 
-export class CsaiAdReporter {
+export class AdReporter {
     private readonly player: ChromelessPlayer;
     private readonly convivaVideoAnalytics: VideoAnalytics;
     private readonly convivaAdAnalytics: AdAnalytics;

--- a/conviva/src/integration/ads/CsaiAdReporter.ts
+++ b/conviva/src/integration/ads/CsaiAdReporter.ts
@@ -116,33 +116,29 @@ export class CsaiAdReporter {
     private addEventListeners(): void {
         this.player.addEventListener('playing', this.onPlaying);
         this.player.addEventListener('pause', this.onPause);
-        if (this.player.ads === undefined) {
-            // should not happen
-            return;
-        }
-        this.player.ads.addEventListener('adbreakbegin', this.onAdBreakBegin);
-        this.player.ads.addEventListener('adbreakend', this.onAdBreakEnd);
-        this.player.ads.addEventListener('adbegin', this.onAdBegin);
-        this.player.ads.addEventListener('adend', this.onAdEnd);
-        this.player.ads.addEventListener('adskip', this.onAdSkip);
-        this.player.ads.addEventListener('adbuffering', this.onAdBuffering);
-        this.player.ads.addEventListener('aderror', this.onAdError);
+        [this.player.ads, this.player.ads?.convivaAdEventsExtension].forEach((dispatcher)=> {
+            dispatcher?.addEventListener('adbreakbegin', this.onAdBreakBegin);
+            dispatcher?.addEventListener('adbreakend', this.onAdBreakEnd);
+            dispatcher?.addEventListener('adbegin', this.onAdBegin);
+            dispatcher?.addEventListener('adend', this.onAdEnd);
+            dispatcher?.addEventListener('adskip', this.onAdSkip);
+            dispatcher?.addEventListener('adbuffering', this.onAdBuffering);
+            dispatcher?.addEventListener('aderror', this.onAdError);
+        });
     }
 
     private removeEventListeners(): void {
         this.player.removeEventListener('playing', this.onPlaying);
         this.player.removeEventListener('pause', this.onPause);
-        if (this.player.ads === undefined) {
-            // should not happen
-            return;
-        }
-        this.player.ads.removeEventListener('adbreakbegin', this.onAdBreakBegin);
-        this.player.ads.removeEventListener('adbreakend', this.onAdBreakEnd);
-        this.player.ads.removeEventListener('adbegin', this.onAdBegin);
-        this.player.ads.removeEventListener('adend', this.onAdEnd);
-        this.player.ads.removeEventListener('adskip', this.onAdSkip);
-        this.player.ads.removeEventListener('adbuffering', this.onAdBuffering);
-        this.player.ads.removeEventListener('aderror', this.onAdError);
+        [this.player.ads, this.player.ads?.convivaAdEventsExtension].forEach((dispatcher)=> {
+            dispatcher?.removeEventListener('adbreakbegin', this.onAdBreakBegin);
+            dispatcher?.removeEventListener('adbreakend', this.onAdBreakEnd);
+            dispatcher?.removeEventListener('adbegin', this.onAdBegin);
+            dispatcher?.removeEventListener('adend', this.onAdEnd);
+            dispatcher?.removeEventListener('adskip', this.onAdSkip);
+            dispatcher?.removeEventListener('adbuffering', this.onAdBuffering);
+            dispatcher?.removeEventListener('aderror', this.onAdError);
+        });
     }
 
     reset(): void {

--- a/conviva/src/integration/extension/ConvivaAdEventsExtension.d.ts
+++ b/conviva/src/integration/extension/ConvivaAdEventsExtension.d.ts
@@ -1,0 +1,10 @@
+import { AdsEventMap, EventDispatcher } from "theoplayer";
+
+declare module "theoplayer" {
+    interface Ads extends EventDispatcher<AdsEventMap> {
+        convivaAdEventsExtension?: EventDispatcher<AdsEventMap>;
+    }
+    class ChromelessPlayer {
+        ads?: Ads;
+    }
+}

--- a/conviva/src/integration/extension/ConvivaAdEventsExtension.d.ts
+++ b/conviva/src/integration/extension/ConvivaAdEventsExtension.d.ts
@@ -1,6 +1,6 @@
-import { AdsEventMap, EventDispatcher } from "theoplayer";
+import { AdsEventMap, EventDispatcher } from 'theoplayer';
 
-declare module "theoplayer" {
+declare module 'theoplayer' {
     interface Ads extends EventDispatcher<AdsEventMap> {
         convivaAdEventsExtension?: EventDispatcher<AdsEventMap>;
     }

--- a/conviva/src/utils/Utils.ts
+++ b/conviva/src/utils/Utils.ts
@@ -17,6 +17,12 @@ export function collectDeviceMetadata(): ConvivaDeviceMetadata {
     };
 }
 
+type AdBreakPosition = 'preroll' | 'midroll' | 'postroll';
+
+export function calculateAdType(player: ChromelessPlayer) {
+    return player.source?.ads?.length ? Constants.AdType.CLIENT_SIDE : Constants.AdType.SERVER_SIDE;
+}
+
 export function calculateVerizonAdBreakInfo(adBreak: VerizonMediaAdBreak, adBreakIndex: number): ConvivaAdBreakInfo {
     return {
         [Constants.POD_DURATION]: adBreak.duration!,
@@ -131,9 +137,6 @@ export function collectAdMetadata(ad: Ad): ConvivaMetadata {
     // [Required] The creative id of the ad. This creative id is from the Ad Server that actually has the ad creative.
     // For wrapper ads, this is the last creative id at the end of the wrapper chain. Set to "NA" if not available.
     adMetadata['c3.ad.creativeId'] = ad.creativeId || 'NA';
-
-    // [Required] The ad technology as CLIENT_SIDE/SERVER_SIDE
-    adMetadata['c3.ad.technology'] = Constants.AdType.CLIENT_SIDE;
 
     // [Required] The ad position as a string "Pre-roll", "Mid-roll" or "Post-roll"
     adMetadata['c3.ad.position'] = calculateCurrentAdBreakPosition(ad.adBreak);

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
       "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
-        "@convivainc/conviva-js-coresdk": "^4.6.1"
+        "@convivainc/conviva-js-coresdk": "^4.7.4"
       },
       "peerDependencies": {
         "@theoplayer/yospace-connector-web": "^2.1.0",
@@ -74,12 +74,6 @@
       "peerDependencies": {
         "theoplayer": "^5.0.0 || ^6.0.0"
       }
-    },
-    "nielsen/node_modules/theoplayer": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/theoplayer/-/theoplayer-5.11.0.tgz",
-      "integrity": "sha512-Ywn3nnTPiyh0cckO3FGIvXfhr3BR16D967voMthnQlwY5jITEJq6pKYAt9qHEXyWNafULKVhY0X///61Wxm7lw==",
-      "peer": true
     },
     "node_modules/@aashutoshrathi/word-wrap": {
       "version": "1.2.6",


### PR DESCRIPTION
Note: this PR was moved from the internal repo.

- Upgraded to conviva SDK 4.7.4
- Added the ability to dispatch/listen for external ad events, not just events originating from the player. This allows to create external ad integrations through the convivaAdEventsExtension.
- The ability to report custom events to conviva, carrying extra information for the current session.