### PR TITLE
Fix bundle size of Conviva connector

### DIFF
--- a/.changeset/thick-carpets-laugh.md
+++ b/.changeset/thick-carpets-laugh.md
@@ -1,0 +1,5 @@
+---
+"@theoplayer/conviva-connector-web": patch
+---
+
+Fixed an issue where the THEOplayer library and the Yospace connector were accidentally bundled together with the Conviva connector.

--- a/cmcd/rollup.config.mjs
+++ b/cmcd/rollup.config.mjs
@@ -10,4 +10,4 @@ const banner = `
  * THEOplayer CMCD Connector v${version}
  */`.trim();
 
-export default getSharedBuildConfiguration(fileName, globalName, banner);
+export default getSharedBuildConfiguration({ fileName, globalName, banner });

--- a/conviva/rollup.config.mjs
+++ b/conviva/rollup.config.mjs
@@ -9,6 +9,10 @@ const banner = `
 /**
  * THEOplayer Conviva Connector v${version}
  */`.trim();
+const external = ['@convivainc/conviva-js-coresdk', '@theoplayer/yospace-connector-web'];
+const globals = {
+    '@convivainc/conviva-js-coresdk': 'Conviva',
+    '@theoplayer/yospace-connector-web': 'THEOplayerYospaceConnector'
+};
 
-
-export default getSharedBuildConfiguration({ fileName, globalName, banner });
+export default getSharedBuildConfiguration({ fileName, globalName, banner, external, globals });

--- a/conviva/rollup.config.mjs
+++ b/conviva/rollup.config.mjs
@@ -11,4 +11,4 @@ const banner = `
  */`.trim();
 
 
-export default getSharedBuildConfiguration(fileName, globalName, banner);
+export default getSharedBuildConfiguration({ fileName, globalName, banner });

--- a/nielsen/rollup.config.mjs
+++ b/nielsen/rollup.config.mjs
@@ -11,4 +11,4 @@ const banner = `
  * Nielsen Web Connector v${version}
  */`.trim();
 
-export default getSharedBuildConfiguration(fileName, globalName, banner);
+export default getSharedBuildConfiguration({ fileName, globalName, banner });

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,14 +52,14 @@
     },
     "conviva": {
       "name": "@theoplayer/conviva-connector-web",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "@convivainc/conviva-js-coresdk": "^4.7.4"
       },
       "peerDependencies": {
         "@theoplayer/yospace-connector-web": "^2.1.0",
-        "theoplayer": "^5.0.0 || ^6.0.0"
+        "theoplayer": "^5.0.0 || ^6.0.0 || ^7.0.0"
       },
       "peerDependenciesMeta": {
         "@theoplayer/yospace-connector-web": {
@@ -69,10 +69,10 @@
     },
     "nielsen": {
       "name": "@theoplayer/nielsen-connector-web",
-      "version": "1.1.0",
+      "version": "1.1.2",
       "license": "MIT",
       "peerDependencies": {
-        "theoplayer": "^5.0.0 || ^6.0.0"
+        "theoplayer": "^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/tools/build.mjs
+++ b/tools/build.mjs
@@ -4,7 +4,7 @@ import commonjs from '@rollup/plugin-commonjs';
 import typescript from '@rollup/plugin-typescript';
 import dts from 'rollup-plugin-dts';
 
-export function getSharedBuildConfiguration({ fileName, globalName, banner = [] }) {
+export function getSharedBuildConfiguration({ fileName, globalName, banner, external, globals }) {
     return defineConfig([
         {
             input: {
@@ -18,7 +18,7 @@ export function getSharedBuildConfiguration({ fileName, globalName, banner = [] 
                     format: 'umd',
                     indent: false,
                     banner,
-                    globals: { theoplayer: 'THEOplayer' }
+                    globals: { theoplayer: 'THEOplayer', ...(globals ?? {}) }
                 },
                 {
                     dir: 'dist',
@@ -28,7 +28,7 @@ export function getSharedBuildConfiguration({ fileName, globalName, banner = [] 
                     banner
                 }
             ],
-            external: ['theoplayer'],
+            external: ['theoplayer', ...(external ?? [])],
             plugins: [
                 nodeResolve({
                     extensions: ['.ts', '.js']
@@ -55,7 +55,7 @@ export function getSharedBuildConfiguration({ fileName, globalName, banner = [] 
                     footer: `export as namespace ${globalName};`
                 }
             ],
-            external: ['theoplayer'],
+            external: ['theoplayer', ...(external ?? [])],
             plugins: [
                 dts({
                     tsconfig: 'tsconfig.json'

--- a/tools/build.mjs
+++ b/tools/build.mjs
@@ -1,61 +1,64 @@
-import {defineConfig} from "rollup";
-import nodeResolve from "@rollup/plugin-node-resolve";
-import commonjs from "@rollup/plugin-commonjs";
-import typescript from "@rollup/plugin-typescript";
-import dts from "rollup-plugin-dts";
+import { defineConfig } from 'rollup';
+import nodeResolve from '@rollup/plugin-node-resolve';
+import commonjs from '@rollup/plugin-commonjs';
+import typescript from '@rollup/plugin-typescript';
+import dts from 'rollup-plugin-dts';
 
-export function getSharedBuildConfiguration({ fileName, globalName, banner }) {
-    return defineConfig([{
-        input: {
-            [fileName]: "src/index.ts"
-        },
-        output: [
-            {
-                dir: "dist",
-                entryFileNames: "[name].umd.js",
-                name: globalName,
-                format: "umd",
-                indent: false,
-                banner,
-                globals: {theoplayer: "THEOplayer"}
+export function getSharedBuildConfiguration({ fileName, globalName, banner = [] }) {
+    return defineConfig([
+        {
+            input: {
+                [fileName]: 'src/index.ts'
             },
-            {
-                dir: "dist",
-                entryFileNames: "[name].esm.js",
-                format: "esm",
-                indent: false,
-                banner
-            }
-        ],
-        plugins: [
-            nodeResolve({
-                extensions: [".ts", ".js"]
-            }),
-            commonjs({
-                include: ['node_modules/**', '../node_modules/**']
-            }),
-            typescript({
-                tsconfig: "tsconfig.json",
-                module: "es2015",
-                include: ["src/**/*"]
-            })
-        ]
-    }, {
-        input: {
-            [fileName]: "src/index.ts"
+            output: [
+                {
+                    dir: 'dist',
+                    entryFileNames: '[name].umd.js',
+                    name: globalName,
+                    format: 'umd',
+                    indent: false,
+                    banner,
+                    globals: { theoplayer: 'THEOplayer' }
+                },
+                {
+                    dir: 'dist',
+                    entryFileNames: '[name].esm.js',
+                    format: 'esm',
+                    indent: false,
+                    banner
+                }
+            ],
+            plugins: [
+                nodeResolve({
+                    extensions: ['.ts', '.js']
+                }),
+                commonjs({
+                    include: ['node_modules/**', '../node_modules/**']
+                }),
+                typescript({
+                    tsconfig: 'tsconfig.json',
+                    module: 'es2015',
+                    include: ['src/**/*']
+                })
+            ]
         },
-        output: [
-            {
-                dir: "dist",
-                format: "esm",
-                banner,
-                footer: `export as namespace ${globalName};`
-            }
-        ],
-        plugins: [
-            dts({
-                tsconfig: "tsconfig.json",
-            })
-        ]
-    }]);
+        {
+            input: {
+                [fileName]: 'src/index.ts'
+            },
+            output: [
+                {
+                    dir: 'dist',
+                    format: 'esm',
+                    banner,
+                    footer: `export as namespace ${globalName};`
+                }
+            ],
+            plugins: [
+                dts({
+                    tsconfig: 'tsconfig.json'
+                })
+            ]
+        }
+    ]);
 }

--- a/tools/build.mjs
+++ b/tools/build.mjs
@@ -28,6 +28,7 @@ export function getSharedBuildConfiguration({ fileName, globalName, banner = [] 
                     banner
                 }
             ],
+            external: ['theoplayer'],
             plugins: [
                 nodeResolve({
                     extensions: ['.ts', '.js']
@@ -54,6 +55,7 @@ export function getSharedBuildConfiguration({ fileName, globalName, banner = [] 
                     footer: `export as namespace ${globalName};`
                 }
             ],
+            external: ['theoplayer'],
             plugins: [
                 dts({
                     tsconfig: 'tsconfig.json'

--- a/tools/build.mjs
+++ b/tools/build.mjs
@@ -4,7 +4,7 @@ import commonjs from "@rollup/plugin-commonjs";
 import typescript from "@rollup/plugin-typescript";
 import dts from "rollup-plugin-dts";
 
-export function getSharedBuildConfiguration(fileName, globalName, banner) {
+export function getSharedBuildConfiguration({ fileName, globalName, banner }) {
     return defineConfig([{
         input: {
             [fileName]: "src/index.ts"

--- a/yospace/rollup.config.mjs
+++ b/yospace/rollup.config.mjs
@@ -10,4 +10,4 @@ const banner = `
  * THEOplayer Yospace Connector v${version}
  */`.trim();
 
-export default getSharedBuildConfiguration(fileName, globalName, banner);
+export default getSharedBuildConfiguration({ fileName, globalName, banner });


### PR DESCRIPTION
[Version 2.0.1 of the Conviva connector](https://www.npmjs.com/package/@theoplayer/conviva-connector-web/v/2.0.1) weighs in at 3.71 MB, because it accidentally bundles both the THEOplayer library and the Yospace connector.

Fix it by marking these as external dependencies in the Rollup configuration. Also, make sure they use the correct global variables when loaded as a `<script>` tag.