### PR TITLE
Ensure CMCD query argument is replaced

### DIFF
--- a/.changeset/slow-melons-mix.md
+++ b/.changeset/slow-melons-mix.md
@@ -1,0 +1,5 @@
+---
+"@theoplayer/cmcd-connector-web": patch
+---
+
+Fixed an issue where multiple CMCD query arguments were being added to the request URL.

--- a/cmcd/src/TransmissionModeStrategies/QueryArgumentTransmissionModeStrategy.ts
+++ b/cmcd/src/TransmissionModeStrategies/QueryArgumentTransmissionModeStrategy.ts
@@ -19,7 +19,7 @@ export class QueryArgumentTransmissionModeStrategy implements TransmissionModeSt
         const url = new URL(request.url);
         const parameters = transformToQueryParameters(payload);
         if (parameters) {
-            url.searchParams.append('CMCD', parameters);
+            url.searchParams.set('CMCD', parameters);
             request.redirect({
                 ...request,
                 url: url.href


### PR DESCRIPTION
The query argument added by the CMCD connector is preserved in subsequent manifest/segment requests by THEOplayer, apparently leading to multiple CMCD arguments being accumulated, which is a problem as the URL grows indefinitely.

Using URLSearchParams set method, rather than append, ensures that the first CMCD argument is updated (the rest are removed) or one is appended.