### PR TITLE
Fix error in Conviva type definitions when Yospace is not installed

### DIFF
--- a/.changeset/nine-buckets-smoke.md
+++ b/.changeset/nine-buckets-smoke.md
@@ -1,0 +1,5 @@
+---
+"@theoplayer/conviva-connector-web": patch
+---
+
+Fixed an issue where TypeScript could throw a TS2307 type error on the generated type definitions when the optional `@theoplayer/yospace-connector-web` peer dependency is not installed.

--- a/.changeset/proud-bottles-reflect.md
+++ b/.changeset/proud-bottles-reflect.md
@@ -1,0 +1,5 @@
+---
+"@theoplayer/conviva-connector-web": minor
+---
+
+Changed Conviva SDK to a peer dependency, enabling users to update it independently from the Conviva connector.

--- a/conviva/package.json
+++ b/conviva/package.json
@@ -33,10 +33,8 @@
     "LICENSE.md",
     "package.json"
   ],
-  "dependencies": {
-    "@convivainc/conviva-js-coresdk": "^4.7.4"
-  },
   "peerDependencies": {
+    "@convivainc/conviva-js-coresdk": "^4.7.4",
     "@theoplayer/yospace-connector-web": "^2.1.1",
     "theoplayer": "^5.0.0 || ^6.0.0 || ^7.0.0"
   },
@@ -44,5 +42,8 @@
     "@theoplayer/yospace-connector-web": {
       "optional": true
     }
+  },
+  "devDependencies": {
+    "@convivainc/conviva-js-coresdk": "^4.7.4"
   }
 }

--- a/conviva/src/integration/ConvivaConnector.ts
+++ b/conviva/src/integration/ConvivaConnector.ts
@@ -1,5 +1,6 @@
 import type { ChromelessPlayer } from 'theoplayer';
 import type { ConvivaMetadata } from '@convivainc/conviva-js-coresdk';
+/** @ts-ignore Optional dependency, will become `any` if not installed. */
 import type { YospaceConnector } from '@theoplayer/yospace-connector-web';
 import { ConvivaConfiguration, ConvivaHandler } from './ConvivaHandler';
 

--- a/conviva/src/integration/ads/YospaceAdReporter.ts
+++ b/conviva/src/integration/ads/YospaceAdReporter.ts
@@ -99,7 +99,8 @@ export class YospaceAdReporter {
     };
 
     private readonly onYospaceSessionError = (code: SessionErrorCode) => {
-        if (code === SessionErrorCode.TIMEOUT) {
+        const yospaceCode = code as number as YospaceSessionErrorCode;
+        if (yospaceCode === YospaceSessionErrorCode.TIMEOUT) {
             this.convivaVideoAnalytics.reportPlaybackError('The Yospace session has timed out.');
         } else {
             this.convivaVideoAnalytics.reportPlaybackError('The Yospace session has errored.');
@@ -120,4 +121,9 @@ export class YospaceAdReporter {
         this.removeEventListeners();
         this.yospaceConnector.unregisterAnalyticEventObserver(this.observer);
     }
+}
+
+// Keep this in sync with SessionErrorCode from yospace-connector-web
+enum YospaceSessionErrorCode {
+    TIMEOUT = 0
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,10 +53,11 @@
       "name": "@theoplayer/conviva-connector-web",
       "version": "2.0.2",
       "license": "MIT",
-      "dependencies": {
+      "devDependencies": {
         "@convivainc/conviva-js-coresdk": "^4.7.4"
       },
       "peerDependencies": {
+        "@convivainc/conviva-js-coresdk": "^4.7.4",
         "@theoplayer/yospace-connector-web": "^2.1.1",
         "theoplayer": "^5.0.0 || ^6.0.0 || ^7.0.0"
       },
@@ -1247,6 +1248,7 @@
     },
     "node_modules/@convivainc/conviva-js-coresdk": {
       "version": "4.7.4",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@cspotcode/source-map-support": {

--- a/yospace/src/yospace/AnalyticEventObserver.ts
+++ b/yospace/src/yospace/AnalyticEventObserver.ts
@@ -2,8 +2,9 @@ import { AdBreak, AdVert } from './AdBreak';
 import { TrackingError } from './TrackingError';
 import { YospaceSessionManager } from './YospaceSessionManager';
 
+// Keep this in sync with YospaceSessionErrorCode from conviva-connector-web
 export enum SessionErrorCode {
-    TIMEOUT
+    TIMEOUT = 0
 }
 
 export interface AnalyticEventObserver {


### PR DESCRIPTION
Previously, TypeScript users would get the following error when they've installed the Conviva connector **without** the (optional) Yospace connector dependency:
```
node_modules/@theoplayer/conviva-connector-web/dist/types/integration/ConvivaConnector.d.ts:3:39 - error TS2307: Cannot find module '@theoplayer/yospace-connector-web' or its corresponding type declarations.

3 import type { YospaceConnector } from '@theoplayer/yospace-connector-web';
                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

This PR works around this issue by adding a `@ts-ignore` comment above that `import`. If the dependency isn't installed, the imported type resolves to `any`, which is good enough.

Note that we need to use a JSDoc-style comment `/** @ts-ignore */` in order for TypeScript to preserve it during emit. A bit hacky, but it works. 😛