### PR TITLE
Offset the playback position from stream start for Yospace DVRLive sessions

### DIFF
--- a/.changeset/thin-crabs-roll.md
+++ b/.changeset/thin-crabs-roll.md
@@ -1,0 +1,5 @@
+---
+"@theoplayer/yospace-connector-web": patch
+---
+
+Fixed playback position reporting for live DVR streams (with `streamType` set to `"livepause"`).

--- a/yospace/src/integration/YospaceManager.ts
+++ b/yospace/src/integration/YospaceManager.ts
@@ -141,7 +141,8 @@ export class YospaceManager extends DefaultEventDispatcher<YospaceEventMap> {
         if (isSessionDVRLive(session)) {
             const ast = session.getManifestData<Date>('availabilityStartTime')?.getTime();
             const sst = session.getStreamStart();
-            const delta = sst - (ast || 0);
+            // availabilityStartTime is initially undefined, and streamStart is initially -1
+            const delta = (sst < 0 ? 0 : sst) - (ast || 0);
             currentTime = Math.round(currentTime - delta);
         }
 

--- a/yospace/src/integration/YospaceManager.ts
+++ b/yospace/src/integration/YospaceManager.ts
@@ -139,9 +139,9 @@ export class YospaceManager extends DefaultEventDispatcher<YospaceEventMap> {
 
         // For Yospace DVRLive sessions we need to offset the playback position from the stream start time
         if (isSessionDVRLive(session)) {
-            const ast = session.getManifestData<Date>('availabilityStartTime');
-            const sst = new Date(session.getStreamStart());
-            const delta = sst?.getTime() - (ast?.getTime() || 0);
+            const ast = session.getManifestData<Date>('availabilityStartTime')?.getTime();
+            const sst = session.getStreamStart();
+            const delta = sst - (ast || 0);
             currentTime = Math.round(currentTime - delta);
         }
 

--- a/yospace/src/yospace/YospaceSessionManager.ts
+++ b/yospace/src/yospace/YospaceSessionManager.ts
@@ -17,12 +17,20 @@ export enum SessionState {
     SHUT_DOWN
 }
 
+export enum PlaybackMode {
+    LIVE = 0,
+    DVRLIVE = 1,
+    VOD = 2
+}
+
 export type YospaceSessionCallback = (state: SessionState, result: ResultCode) => void;
 export type YospaceSessionManagerCreator = {
     create(url: string, properties: object, successCallback: YospaceSessionCallback): void;
 };
 
-export interface YospaceSessionManager {
+export interface YospaceSession {
+    getPlaybackMode(): PlaybackMode;
+
     getPlaybackUrl(): string;
 
     getResultCode(): number;
@@ -41,3 +49,24 @@ export interface YospaceSessionManager {
 
     shutdown(): void;
 }
+
+export interface YospaceSessionDVRLive extends YospaceSession {
+    getPlaybackMode(): PlaybackMode.DVRLIVE;
+
+    getDuration(): number;
+
+    getStreamStart(): number;
+
+    getManifestData<T>(key: string): T | undefined;
+    getManifestData(): Map<string, any>;
+
+    getWindowStart(): number;
+
+    getWindowEnd(): number;
+
+    getWindowSize(): number;
+
+    setAdBreaksInactivePriorTo(playhead: number): void;
+}
+
+export { YospaceSession as YospaceSessionManager };


### PR DESCRIPTION
The current behaviour of the THEOplayer Yospace web connector is to always report the player current time to the Yospace SDK regardless of the playback mode. But for Yospace DVRLive sessions (called `livepause` in the connector) the time should be offset from stream start.

See https://developer.yospace.com/sdk-documentation/javascript/userguide/latest/en/provide-necessary-information-to-the-sdk.html#video-playback-position for more information.

Examples of this logic is also available in the Yospace sample reference apps (see shaka/shaka-adapter.js).