### PR TITLE
Add `destroy()` method

### DIFF
--- a/.changeset/little-bats-wave.md
+++ b/.changeset/little-bats-wave.md
@@ -1,0 +1,5 @@
+---
+"@theoplayer/yospace-connector-web": minor
+---
+
+Added a destroy method to shutdown the current Yospace session.

--- a/yospace/README.md
+++ b/yospace/README.md
@@ -89,3 +89,10 @@ await yospaceConnector.setupYospaceSession(source, sessionProperties);
 ```
 
 Once the setup of the Yospace session is done, you can continue to use the player and the connector will handle everything related to Yospace.
+
+To shutdown the current Yospace session, use the connector's `destroy()` method. The connector automatically calls `session.shutdown()` on session initialization errors and when creating a new session. If you, however, set a non-yospace source to the player after using this connector, it is your responsibility to do this through `destroy()`.
+
+```javascript
+yospaceConnector.destroy();
+player.source = SOME_NON_YOSPACE_SOURCE;
+```

--- a/yospace/src/integration/YospaceConnector.ts
+++ b/yospace/src/integration/YospaceConnector.ts
@@ -48,6 +48,13 @@ export class YospaceConnector implements EventDispatcher<YospaceEventMap> {
     }
 
     /**
+     * Destroy the current session instance once it's no longer required, in order to prevent possible resource leaks on the viewer's device. 
+     */
+    destroy() {
+        this.yospaceManager.reset();
+    }
+
+    /**
      * Unregister an analytics event observer from the Yospace SDK.
      *
      * @param analyticEventObserver the observer that will be unregistered from the Yospace SDK.

--- a/yospace/src/integration/YospaceManager.ts
+++ b/yospace/src/integration/YospaceManager.ts
@@ -233,7 +233,7 @@ export class YospaceManager extends DefaultEventDispatcher<YospaceEventMap> {
         }
     };
 
-    private reset() {
+    reset() {
         this.removeEventListenersToNotifyYospace();
         this.sessionManager?.shutdown();
         clearInterval(this.playbackPositionUpdater);


### PR DESCRIPTION
1. ~~Updated `updateYospaceWithPlaybackPosition` to report the currentTime offset wrt `session.getStreamStart()`~~  
  (Superseded by #23)
2. Added a public `destroy()` method to the connector, to allow users to shutdown the current yospace session. E.g. for when a non-yospace source will be set to the player. Right now this shutdown only happens when setting a new yospace source or when initialization of the session fails.