### PR TITLE
Report average bitrate to Conviva

### DIFF
--- a/.changeset/long-dolphins-rest.md
+++ b/.changeset/long-dolphins-rest.md
@@ -1,0 +1,5 @@
+---
+"@theoplayer/conviva-connector-web": patch
+---
+
+Report average bitrate to Conviva.

--- a/conviva/src/integration/ConvivaHandler.ts
+++ b/conviva/src/integration/ConvivaHandler.ts
@@ -203,7 +203,10 @@ export class ConvivaHandler {
                 activeQuality.bandwidth / 1000
             );
             if (activeQuality.averageBandwidth) {
-                this.convivaVideoAnalytics!.reportPlaybackMetric(Constants.Playback.AVG_BITRATE, activeQuality.averageBandwidth / 1000)
+                this.convivaVideoAnalytics!.reportPlaybackMetric(
+                    Constants.Playback.AVG_BITRATE,
+                    activeQuality.averageBandwidth / 1000
+                );
             }
             if (frameRate) {
                 this.convivaVideoAnalytics!.reportPlaybackMetric(Constants.Playback.RENDERED_FRAMERATE, frameRate);

--- a/conviva/src/integration/ConvivaHandler.ts
+++ b/conviva/src/integration/ConvivaHandler.ts
@@ -202,6 +202,9 @@ export class ConvivaHandler {
                 Constants.Playback.BITRATE,
                 activeQuality.bandwidth / 1000
             );
+            if (activeQuality.averageBandwidth) {
+                this.convivaVideoAnalytics!.reportPlaybackMetric(Constants.Playback.AVG_BITRATE, activeQuality.averageBandwidth / 1000)
+            }
             if (frameRate) {
                 this.convivaVideoAnalytics!.reportPlaybackMetric(Constants.Playback.RENDERED_FRAMERATE, frameRate);
             }


### PR DESCRIPTION
These changes were accidentally lost when moving the Conviva connector to this monorepo. This PR pulls them back in.