### PR TITLE
Bugfix/custom metadata not passed on replay

### DIFF
--- a/.changeset/silly-carrots-visit.md
+++ b/.changeset/silly-carrots-visit.md
@@ -1,5 +1,5 @@
 ---
-"@theoplayer/conviva-connector-web": minor
+"@theoplayer/conviva-connector-web": patch
 ---
 
 Fixed an issue where the metadata is not passed correctly after a replay.

--- a/.changeset/silly-carrots-visit.md
+++ b/.changeset/silly-carrots-visit.md
@@ -1,0 +1,5 @@
+---
+"@theoplayer/conviva-connector-web": minor
+---
+
+Fixed an issue where the metadata is not passed correctly after a replay.

--- a/conviva/src/integration/ConvivaHandler.ts
+++ b/conviva/src/integration/ConvivaHandler.ts
@@ -112,7 +112,7 @@ export class ConvivaHandler {
             this.initializeSession();
         }
         this.customMetadata = { ...this.customMetadata, ...metadata };
-        this.convivaVideoAnalytics!.setContentInfo(metadata);
+        this.convivaVideoAnalytics!.setContentInfo(this.customMetadata);
     }
 
     setAdInfo(metadata: ConvivaMetadata): void {

--- a/conviva/src/integration/ConvivaHandler.ts
+++ b/conviva/src/integration/ConvivaHandler.ts
@@ -333,6 +333,7 @@ export class ConvivaHandler {
     private readonly onSourceChange = () => {
         this.maybeReportPlaybackEnded();
         this.currentSource = this.player.source;
+        this.customMetadata = {};
     };
 
     private readonly onEnded = () => {
@@ -371,13 +372,12 @@ export class ConvivaHandler {
         this.convivaVideoAnalytics?.release();
         this.convivaAdAnalytics = undefined;
         this.convivaVideoAnalytics = undefined;
-
-        this.customMetadata = {};
     }
 
     destroy(): void {
         this.maybeReportPlaybackEnded();
         this.removeEventListeners();
+        this.customMetadata = {};
         Analytics.release();
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
     },
     "conviva": {
       "name": "@theoplayer/conviva-connector-web",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "MIT",
       "devDependencies": {
         "@convivainc/conviva-js-coresdk": "^4.7.4"
@@ -8737,7 +8737,7 @@
     },
     "yospace": {
       "name": "@theoplayer/yospace-connector-web",
-      "version": "2.1.3",
+      "version": "2.2.0",
       "license": "MIT",
       "peerDependencies": {
         "theoplayer": "^5.0.0 || ^6.0.0 || ^7.0.0"


### PR DESCRIPTION
If the user replays the video, a new Conviva session will be created. But this new session will not contain the previous added custom metadata.

This PR fixes this issue.