### PR TITLE
Add Yospace configuration types to connector

### DIFF
--- a/.changeset/khaki-clocks-flow.md
+++ b/.changeset/khaki-clocks-flow.md
@@ -1,0 +1,6 @@
+---
+"@theoplayer/yospace-connector-web": minor
+---
+
+Added `YospaceServerSideAdInsertionConfiguration` type definition to the connector,
+superseding the type defined by the THEOplayer Web SDK.

--- a/yospace/src/index.ts
+++ b/yospace/src/index.ts
@@ -1,4 +1,5 @@
 export * from './integration/YospaceConnector';
+export * from './integration/YospaceConfiguration';
 export { AnalyticEventObserver, SessionErrorCode } from './yospace/AnalyticEventObserver';
 export * from './yospace/AdBreak';
 export { SessionProperties } from './yospace/SessionProperties';

--- a/yospace/src/integration/YospaceConfiguration.ts
+++ b/yospace/src/integration/YospaceConfiguration.ts
@@ -1,0 +1,32 @@
+import type { ServerSideAdInsertionConfiguration } from 'theoplayer';
+
+/**
+ * The identifier of the Yospace integration.
+ */
+export type YospaceSSAIIntegrationID = 'yospace';
+
+/**
+ * The type of the Yospace stream, represented by a value from the following list:
+ * <br/> - `'live'`: The stream is a live stream.
+ * <br/> - `'livepause'`: The stream is a live stream with a large DVR window.
+ * <br/> - `'nonlinear'`: The stream is a Non-Linear Start-Over stream.
+ * <br/> - `'vod'`: The stream is a video-on-demand stream.
+ */
+export type YospaceStreamType = 'vod' | 'live' | 'livepause' | 'nonlinear';
+
+/**
+ * Represents a configuration for server-side ad insertion with the Yospace pre-integration.
+ */
+export interface YospaceServerSideAdInsertionConfiguration extends ServerSideAdInsertionConfiguration {
+    /**
+     * The identifier for the SSAI pre-integration.
+     */
+    integration: YospaceSSAIIntegrationID;
+
+    /**
+     * The type of the requested stream.
+     *
+     * @defaultValue `'live'`
+     */
+    streamType?: YospaceStreamType;
+}

--- a/yospace/src/integration/YospaceConfiguration.ts
+++ b/yospace/src/integration/YospaceConfiguration.ts
@@ -7,19 +7,19 @@ export type YospaceSSAIIntegrationID = 'yospace';
 
 /**
  * The type of the Yospace stream, represented by a value from the following list:
- * <br/> - `'live'`: The stream is a live stream.
- * <br/> - `'livepause'`: The stream is a live stream with a large DVR window.
- * <br/> - `'nonlinear'`: The stream is a Non-Linear Start-Over stream.
- * <br/> - `'vod'`: The stream is a video-on-demand stream.
+ *  - `'live'`: The stream is a live stream.
+ *  - `'livepause'`: The stream is a live stream with a large DVR window.
+ *  - `'nonlinear'`: The stream is a Non-Linear Start-Over stream.
+ *  - `'vod'`: The stream is a video-on-demand stream.
  */
 export type YospaceStreamType = 'vod' | 'live' | 'livepause' | 'nonlinear';
 
 /**
- * Represents a configuration for server-side ad insertion with the Yospace pre-integration.
+ * Represents a configuration for server-side ad insertion with Yospace using the {@link YospaceConnector}.
  */
 export interface YospaceServerSideAdInsertionConfiguration extends ServerSideAdInsertionConfiguration {
     /**
-     * The identifier for the SSAI pre-integration.
+     * The identifier for the Yospace integration.
      */
     integration: YospaceSSAIIntegrationID;
 

--- a/yospace/src/integration/YospaceConnector.ts
+++ b/yospace/src/integration/YospaceConnector.ts
@@ -27,8 +27,12 @@ export class YospaceConnector implements EventDispatcher<YospaceEventMap> {
      *
      * As of THEOplayer 7.4.0, you can also set `player.source` directly instead of using this method.
      *
-     * @param sourceDescription the source that will be used to create the Yospace session.
-     * @param sessionProperties the properties that will be used set to customize the Yospace session.
+     * @param sourceDescription
+     *   The source that will be used to create the Yospace session.
+     *   This should have at least one {@link SourceDescription.sources | source} whose {@link TypedSource.ssai}
+     *   is a {@link YospaceServerSideAdInsertionConfiguration}.
+     * @param sessionProperties
+     *   The properties that will be used set to customize the Yospace session.
      * @throws `Error` if the Yospace Ad Management SDK is not available.
      * @throws `Error` if something goes wrong in setting up the session.
      */

--- a/yospace/src/integration/YospaceUIHandler.ts
+++ b/yospace/src/integration/YospaceUIHandler.ts
@@ -1,4 +1,3 @@
-import { YospaceSessionManager } from '../yospace/YospaceSessionManager';
 import { Creative, LinearCreative, NonLinearCreative } from '../yospace/AdBreak';
 
 export function stretchToParent(element: HTMLElement): void {

--- a/yospace/src/utils/YospaceUtils.ts
+++ b/yospace/src/utils/YospaceUtils.ts
@@ -1,13 +1,16 @@
+import type { SourceDescription, TypedSource } from 'theoplayer';
 import type {
-    SourceDescription,
     YospaceServerSideAdInsertionConfiguration,
-    YospaceSSAIIntegrationID,
-    YospaceTypedSource
-} from 'theoplayer';
+    YospaceSSAIIntegrationID
+} from '../integration/YospaceConfiguration';
 import { implementsInterface, isTypedSource, toSources } from './SourceUtils';
 import { YospaceWindow } from '../yospace/YospaceWindow';
 
 export const YOSPACE_SSAI_INTEGRATION_ID: YospaceSSAIIntegrationID = 'yospace';
+
+export interface YospaceTypedSource extends TypedSource {
+    ssai: YospaceServerSideAdInsertionConfiguration;
+}
 
 export function isYoSpaceServerSideAdInsertionConfiguration(
     ssai: any


### PR DESCRIPTION
The `YospaceServerSideAdInsertionConfiguration` is currently [defined in the THEOplayer Web SDK](https://www.theoplayer.com/docs/theoplayer/v7/api-reference/web/interfaces/YospaceServerSideAdInsertionConfiguration.html), and imported by the Yospace connector. This is not ideal:
* If the connector wanted to add or change the configuration interface, it would need a new THEOplayer release first.
* Since we intend to deprecate (and eventually remove) the Yospace pre-integration shipped in THEOplayer itself, the configuration should be moved out of the Web SDK.

This PR adds the `YospaceServerSideAdInsertionConfiguration` type to the Yospace Connector itself. It is currently identical to the one shipped with THEOplayer, so customers won't need to change anything in their code. However, we highly recommend updating the imports in your code to use the connector's types, in preparation of a future removal from the Web SDK.