### PR TITLE
Feature/nielsen dcr

### DIFF
--- a/nielsen/package.json
+++ b/nielsen/package.json
@@ -20,7 +20,7 @@
     "bundle": "rollup -c rollup.config.mjs",
     "watch": "npm run bundle -- --watch",
     "build": "npm run clean && npm run bundle",
-    "serve": "http-server",
+    "serve": "http-server ./.. -o /nielsen/test/pages/main.html",
     "test": "jest"
   },
   "author": "THEO Technologies NV",

--- a/nielsen/src/index.ts
+++ b/nielsen/src/index.ts
@@ -1,2 +1,2 @@
 export { NielsenConnector } from './integration/NielsenConnector';
-export { NielsenOptions } from './nielsen/Types';
+export { NielsenOptions, NielsenDCRContentMetadata, NielsenDCRContentMetadataCZ } from './nielsen/Types';

--- a/nielsen/src/integration/NielsenConnector.ts
+++ b/nielsen/src/integration/NielsenConnector.ts
@@ -21,6 +21,10 @@ export class NielsenConnector {
         this.nielsenHandler.updateMetadata(metadata);
     }
 
+    updateDCRContentMetadata(metadata: NielsenDCRContentMetadata): void {
+        this.nielsenHandler.updateDCRContentMetadata(metadata);
+    }
+
     destroy() {
         this.nielsenHandler.destroy();
     }

--- a/nielsen/src/integration/NielsenConnector.ts
+++ b/nielsen/src/integration/NielsenConnector.ts
@@ -13,8 +13,14 @@ export class NielsenConnector {
      * @param instanceName  User-defined string value for describing the player/site.
      * @param options       Additional options.
      */
-    constructor(player: ChromelessPlayer, appId: string, instanceName: string, options?: NielsenOptions) {
-        this.nielsenHandler = new NielsenHandler(player, appId, instanceName, options);
+    constructor(
+        player: ChromelessPlayer,
+        appId: string,
+        instanceName: string,
+        options?: NielsenOptions,
+        configuration?: NielsenConfiguration
+    ) {
+        this.nielsenHandler = new NielsenHandler(player, appId, instanceName, options, configuration);
     }
 
     updateMetadata(metadata: { [key: string]: string }): void {

--- a/nielsen/src/integration/NielsenConnector.ts
+++ b/nielsen/src/integration/NielsenConnector.ts
@@ -1,5 +1,5 @@
 import type { ChromelessPlayer } from 'theoplayer';
-import { NielsenOptions } from '../nielsen/Types';
+import { NielsenConfiguration, NielsenDCRContentMetadata, NielsenOptions } from '../nielsen/Types';
 import { NielsenHandler } from './NielsenHandler';
 
 export class NielsenConnector {

--- a/nielsen/src/integration/NielsenHandler.ts
+++ b/nielsen/src/integration/NielsenHandler.ts
@@ -214,12 +214,14 @@ export class NielsenHandler {
 
     private maybeSendPlayEvent(): void {
         if (this.sessionInProgress || Number.isNaN(this.duration)) return;
-        this.sessionInProgress = true;
-        const metadataObject = {
-            channelName: this.player.src,
-            length: this.duration
-        };
-        this.nSdkInstance.ggPM('play', metadataObject);
+        if (this.dtvrEnabled) {
+            this.sessionInProgress = true;
+            const metadataObject = {
+                channelName: this.player.src,
+                length: this.duration
+            };
+            this.nSdkInstance.ggPM('play', metadataObject);
+        }
     }
 
     private endSession(): void {

--- a/nielsen/src/integration/NielsenHandler.ts
+++ b/nielsen/src/integration/NielsenHandler.ts
@@ -239,7 +239,7 @@ export class NielsenHandler {
         this.nSdkInstance.ggPM('stop', this.getPlayHeadPosition());
     };
 
-    private onAdBreakBegin = ({ adBreak }: AdBreakEvent<'begin'>) => {
+    private onAdBreakBegin = ({ adBreak }: AdBreakEvent<'adbreakbegin'>) => {
         if (!this.dcrEnabled) return;
         const isPostroll = getAdType(adBreak) === 'postroll';
         if (!isPostroll) return;

--- a/nielsen/src/integration/NielsenHandler.ts
+++ b/nielsen/src/integration/NielsenHandler.ts
@@ -72,7 +72,8 @@ export class NielsenHandler {
     }
 
     updateDCRContentMetadata(metadata: DCRContentMetadata): void {
-        if (this.dcrEnabled) this.metadata = metadata;
+        if (!this.dcrEnabled) return;
+        this.metadata = metadata;
     }
 
     private addEventListeners(): void {

--- a/nielsen/src/integration/NielsenHandler.ts
+++ b/nielsen/src/integration/NielsenHandler.ts
@@ -17,9 +17,10 @@ import {
     DTVRContentMetadata,
     NielsenConfiguration,
     NielsenCountry,
+    NielsenDCRContentMetadata,
     NielsenOptions
 } from '../nielsen/Types';
-import { buildDCRAdMetadata, getAdType } from '../utils/Util';
+import { buildDCRAdMetadata, buildDCRContentMetadata, getAdType } from '../utils/Util';
 
 const EMSG_PRIV_SUFFIX = 'PRIV{';
 const EMSG_PAYLOAD_SUFFIX = 'payload=';
@@ -71,9 +72,9 @@ export class NielsenHandler {
         }
     }
 
-    updateDCRContentMetadata(metadata: DCRContentMetadata): void {
+    updateDCRContentMetadata(metadata: NielsenDCRContentMetadata): void {
         if (!this.dcrEnabled) return;
-        this.metadata = metadata;
+        this.metadata = buildDCRContentMetadata(metadata, this.country);
     }
 
     private addEventListeners(): void {

--- a/nielsen/src/integration/NielsenHandler.ts
+++ b/nielsen/src/integration/NielsenHandler.ts
@@ -121,6 +121,7 @@ export class NielsenHandler {
     };
 
     private onEnd = () => {
+        if (this.dcrEnabled && this.player.ads?.playing) this.nSdkInstance.ggPM('stop', this.getPlayHeadPosition());
         this.endSession();
     };
 

--- a/nielsen/src/integration/NielsenHandler.ts
+++ b/nielsen/src/integration/NielsenHandler.ts
@@ -51,7 +51,22 @@ export class NielsenHandler {
     }
 
     updateMetadata(metadata: { [key: string]: string }): void {
-        this.nSdkInstance.ggPM('updateMetadata', metadata);
+        switch (this.country) {
+            case NielsenCountry.US: {
+                const { type, vidtype, assetid, ...updateableParameters } = metadata;
+                console.log(`[NIELSEN] updateMetadata: ${{ type, vidtype, assetid }} will not be updated`);
+                this.nSdkInstance.ggPM('updateMetadata', updateableParameters);
+                // ex
+                break;
+            }
+            case NielsenCountry.CZ:
+            default:
+            //
+        }
+    }
+
+    updateDCRContentMetadata(metadata: DCRContentMetadata): void {
+        if (this.dcrEnabled) this.metadata = metadata;
     }
 
     private addEventListeners(): void {

--- a/nielsen/src/integration/NielsenHandler.ts
+++ b/nielsen/src/integration/NielsenHandler.ts
@@ -203,7 +203,7 @@ export class NielsenHandler {
     };
 
     private onAdBegin = () => {
-        const currentAd = this.player.ads!.currentAds.filter((ad: Ad) => ad.type === 'linear');
+        const currentAd = this.player.ads!.currentAds.filter((ad: Ad) => ad.type === 'linear'); // TODO check why we chose to not use the ad from the event payload
         const type = getAdType(this.player.ads!.currentAdBreak!);
         if (this.dtvrEnabled) {
             const dtvrAdMetadata: AdMetadata = {
@@ -213,7 +213,7 @@ export class NielsenHandler {
             this.nSdkInstance.ggPM('loadMetadata', dtvrAdMetadata);
         }
         if (this.dcrEnabled) {
-            const dcrAdMetadata = buildDCRAdMetadata(currentAd);
+            const dcrAdMetadata = buildDCRAdMetadata(currentAd[0], this.country);
             this.nSdkInstance.ggPM('loadMetadata', dcrAdMetadata);
         }
     };

--- a/nielsen/src/integration/NielsenHandler.ts
+++ b/nielsen/src/integration/NielsenHandler.ts
@@ -248,7 +248,7 @@ export class NielsenHandler {
             this.nSdkInstance.ggPM('loadMetadata', dtvrAdMetadata);
         }
         if (this.dcrEnabled) {
-            const dcrAdMetadata = buildDCRAdMetadata(currentAd[0], this.country);
+            const dcrAdMetadata = buildDCRAdMetadata(currentAd[0], this.country, this.duration);
             this.nSdkInstance.ggPM('loadMetadata', dcrAdMetadata);
         }
     };

--- a/nielsen/src/integration/NielsenHandler.ts
+++ b/nielsen/src/integration/NielsenHandler.ts
@@ -134,6 +134,7 @@ export class NielsenHandler {
     };
 
     private onTimeUpdate = ({ currentTime }: TimeUpdateEvent) => {
+        if (!this.dcrEnabled) return;
         const currentTimeFloor = Math.floor(currentTime);
         if (currentTimeFloor === this.lastReportedPlayheadPosition) return;
         this.lastReportedPlayheadPosition = currentTimeFloor;

--- a/nielsen/src/integration/NielsenHandler.ts
+++ b/nielsen/src/integration/NielsenHandler.ts
@@ -1,5 +1,6 @@
 import type {
     Ad,
+    AdBreakEvent,
     AddTrackEvent,
     ChromelessPlayer,
     TextTrack,
@@ -236,6 +237,13 @@ export class NielsenHandler {
     private onAdEnd = () => {
         if (!this.dcrEnabled) return;
         this.nSdkInstance.ggPM('stop', this.getPlayHeadPosition());
+    };
+
+    private onAdBreakBegin = ({ adBreak }: AdBreakEvent<'begin'>) => {
+        if (!this.dcrEnabled) return;
+        const isPostroll = getAdType(adBreak) === 'postroll';
+        if (!isPostroll) return;
+        this.endSession();
     };
 
     private maybeSendPlayEvent(): void {

--- a/nielsen/src/integration/NielsenHandler.ts
+++ b/nielsen/src/integration/NielsenHandler.ts
@@ -3,6 +3,7 @@ import type {
     AdBreakEvent,
     AddTrackEvent,
     ChromelessPlayer,
+    DurationChangeEvent,
     TextTrack,
     TextTrackEnterCueEvent,
     TimeUpdateEvent,
@@ -133,7 +134,8 @@ export class NielsenHandler {
         this.nSdkInstance.ggPM('setVolume', volumeLevel);
     };
 
-    private onDurationChange = () => {
+    private onDurationChange = ({ duration }: DurationChangeEvent) => {
+        if (isNaN(duration)) return;
         this.duration = this.player.duration;
         this.maybeSendPlayEvent();
     };

--- a/nielsen/src/integration/NielsenHandler.ts
+++ b/nielsen/src/integration/NielsenHandler.ts
@@ -15,7 +15,7 @@ import {
     NielsenCountry,
     NielsenOptions
 } from '../nielsen/Types';
-import { getAdType } from '../utils/Util';
+import { buildDCRAdMetadata, getAdType } from '../utils/Util';
 
 const EMSG_PRIV_SUFFIX = 'PRIV{';
 const EMSG_PAYLOAD_SUFFIX = 'payload=';

--- a/nielsen/src/integration/NielsenHandler.ts
+++ b/nielsen/src/integration/NielsenHandler.ts
@@ -271,8 +271,8 @@ export class NielsenHandler {
 
     private maybeSendPlayEvent(): void {
         if (this.sessionInProgress || Number.isNaN(this.duration)) return;
+        this.sessionInProgress = true;
         if (this.dtvrEnabled) {
-            this.sessionInProgress = true;
             const metadataObject = {
                 channelName: this.player.src,
                 length: this.duration

--- a/nielsen/src/integration/NielsenHandler.ts
+++ b/nielsen/src/integration/NielsenHandler.ts
@@ -89,6 +89,7 @@ export class NielsenHandler {
         if (this.player.ads) {
             this.player.ads.addEventListener('adbegin', this.onAdBegin);
             this.player.ads.addEventListener('adend', this.onAdEnd);
+            this.player.ads.addEventListener('adbreakbegin', this.onAdBreakBegin);
         }
 
         window.addEventListener('beforeunload', this.onEnd);
@@ -108,6 +109,7 @@ export class NielsenHandler {
         if (this.player.ads) {
             this.player.ads.removeEventListener('adbegin', this.onAdBegin);
             this.player.ads.removeEventListener('adend', this.onAdEnd);
+            this.player.ads.removeEventListener('adbreakbegin', this.onAdBreakBegin);
         }
 
         window.removeEventListener('beforeunload', this.onEnd);

--- a/nielsen/src/integration/NielsenHandler.ts
+++ b/nielsen/src/integration/NielsenHandler.ts
@@ -9,6 +9,7 @@ import type {
 import { loadNielsenLibrary } from '../nielsen/NOLBUNDLE';
 import {
     AdMetadata,
+    DCRContentMetadata,
     DTVRContentMetadata,
     NielsenConfiguration,
     NielsenCountry,
@@ -25,6 +26,8 @@ export class NielsenHandler {
     private dcrEnabled: boolean;
     private dtvrEnabled: boolean;
     private country: NielsenCountry = NielsenCountry.US;
+
+    private metadata: DCRContentMetadata | undefined;
 
     private nSdkInstance: any;
 

--- a/nielsen/src/integration/NielsenHandler.ts
+++ b/nielsen/src/integration/NielsenHandler.ts
@@ -212,14 +212,13 @@ export class NielsenHandler {
     };
 
     private maybeSendPlayEvent(): void {
-        if (!this.sessionInProgress && !Number.isNaN(this.duration)) {
-            this.sessionInProgress = true;
-            const metadataObject = {
-                channelName: this.player.src,
-                length: this.duration
-            };
-            this.nSdkInstance.ggPM('play', metadataObject);
-        }
+        if (this.sessionInProgress || Number.isNaN(this.duration)) return;
+        this.sessionInProgress = true;
+        const metadataObject = {
+            channelName: this.player.src,
+            length: this.duration
+        };
+        this.nSdkInstance.ggPM('play', metadataObject);
     }
 
     private endSession(): void {

--- a/nielsen/src/integration/NielsenHandler.ts
+++ b/nielsen/src/integration/NielsenHandler.ts
@@ -87,6 +87,7 @@ export class NielsenHandler {
 
         if (this.player.ads) {
             this.player.ads.addEventListener('adbegin', this.onAdBegin);
+            this.player.ads.addEventListener('adend', this.onAdEnd);
         }
 
         window.addEventListener('beforeunload', this.onEnd);
@@ -105,6 +106,7 @@ export class NielsenHandler {
 
         if (this.player.ads) {
             this.player.ads.removeEventListener('adbegin', this.onAdBegin);
+            this.player.ads.removeEventListener('adend', this.onAdEnd);
         }
 
         window.removeEventListener('beforeunload', this.onEnd);
@@ -229,6 +231,11 @@ export class NielsenHandler {
             const dcrAdMetadata = buildDCRAdMetadata(currentAd[0], this.country);
             this.nSdkInstance.ggPM('loadMetadata', dcrAdMetadata);
         }
+    };
+
+    private onAdEnd = () => {
+        if (!this.dcrEnabled) return;
+        this.nSdkInstance.ggPM('stop', this.getPlayHeadPosition());
     };
 
     private maybeSendPlayEvent(): void {

--- a/nielsen/src/integration/NielsenHandler.ts
+++ b/nielsen/src/integration/NielsenHandler.ts
@@ -130,6 +130,7 @@ export class NielsenHandler {
     };
 
     private onLoadMetadata = () => {
+        if (!this.dtvrEnabled) return;
         const data: DTVRContentMetadata = {
             type: 'content',
             adModel: '1' // Always '1' for DTVR

--- a/nielsen/src/integration/NielsenHandler.ts
+++ b/nielsen/src/integration/NielsenHandler.ts
@@ -130,6 +130,7 @@ export class NielsenHandler {
     };
 
     private onVolumeChange = (event: VolumeChangeEvent) => {
+        if (!this.dtvrEnabled) return;
         const volumeLevel = this.player.muted ? 0 : event.volume * 100;
         this.nSdkInstance.ggPM('setVolume', volumeLevel);
     };

--- a/nielsen/src/integration/NielsenHandler.ts
+++ b/nielsen/src/integration/NielsenHandler.ts
@@ -205,11 +205,17 @@ export class NielsenHandler {
     private onAdBegin = () => {
         const currentAd = this.player.ads!.currentAds.filter((ad: Ad) => ad.type === 'linear');
         const type = getAdType(this.player.ads!.currentAdBreak!);
-        const adMetadata: AdMetadata = {
-            type,
-            assetid: currentAd[0].id!
-        };
-        this.nSdkInstance.ggPM('loadMetadata', adMetadata);
+        if (this.dtvrEnabled) {
+            const dtvrAdMetadata: AdMetadata = {
+                type,
+                assetid: currentAd[0].id!
+            };
+            this.nSdkInstance.ggPM('loadMetadata', dtvrAdMetadata);
+        }
+        if (this.dcrEnabled) {
+            const dcrAdMetadata = buildDCRAdMetadata(currentAd);
+            this.nSdkInstance.ggPM('loadMetadata', dcrAdMetadata);
+        }
     };
 
     private maybeSendPlayEvent(): void {

--- a/nielsen/src/integration/NielsenHandler.ts
+++ b/nielsen/src/integration/NielsenHandler.ts
@@ -151,6 +151,7 @@ export class NielsenHandler {
     };
 
     private onAddTrack = (event: AddTrackEvent) => {
+        if (!this.dtvrEnabled) return;
         if (event.track.kind === 'metadata') {
             const track = event.track as TextTrack;
             if (track.type === 'id3' || track.type === 'emsg') {

--- a/nielsen/src/integration/NielsenHandler.ts
+++ b/nielsen/src/integration/NielsenHandler.ts
@@ -7,7 +7,7 @@ import type {
     VolumeChangeEvent
 } from 'theoplayer';
 import { loadNielsenLibrary } from '../nielsen/NOLBUNDLE';
-import { AdMetadata, ContentMetadata, NielsenOptions } from '../nielsen/Types';
+import { AdMetadata, DTVRContentMetadata, NielsenOptions } from '../nielsen/Types';
 import { getAdType } from '../utils/Util';
 
 const EMSG_PRIV_SUFFIX = 'PRIV{';
@@ -93,7 +93,7 @@ export class NielsenHandler {
     };
 
     private onLoadMetadata = () => {
-        const data: ContentMetadata = {
+        const data: DTVRContentMetadata = {
             type: 'content',
             adModel: '1' // Always '1' for DTVR
         };

--- a/nielsen/src/integration/NielsenHandler.ts
+++ b/nielsen/src/integration/NielsenHandler.ts
@@ -222,6 +222,9 @@ export class NielsenHandler {
             };
             this.nSdkInstance.ggPM('play', metadataObject);
         }
+        if (this.dcrEnabled) {
+            this.nSdkInstance.ggPM('loadMetadata', this.metadata);
+        }
     }
 
     private endSession(): void {

--- a/nielsen/src/integration/NielsenHandler.ts
+++ b/nielsen/src/integration/NielsenHandler.ts
@@ -7,7 +7,13 @@ import type {
     VolumeChangeEvent
 } from 'theoplayer';
 import { loadNielsenLibrary } from '../nielsen/NOLBUNDLE';
-import { AdMetadata, DTVRContentMetadata, NielsenConfiguration, NielsenOptions } from '../nielsen/Types';
+import {
+    AdMetadata,
+    DTVRContentMetadata,
+    NielsenConfiguration,
+    NielsenCountry,
+    NielsenOptions
+} from '../nielsen/Types';
 import { getAdType } from '../utils/Util';
 
 const EMSG_PRIV_SUFFIX = 'PRIV{';
@@ -15,6 +21,10 @@ const EMSG_PAYLOAD_SUFFIX = 'payload=';
 
 export class NielsenHandler {
     private player: ChromelessPlayer;
+
+    private dcrEnabled: boolean;
+    private dtvrEnabled: boolean;
+    private country: NielsenCountry = NielsenCountry.US;
 
     private nSdkInstance: any;
 
@@ -28,11 +38,14 @@ export class NielsenHandler {
         player: ChromelessPlayer,
         appId: string,
         instanceName: string,
-        configuration: NielsenConfiguration,
-        options?: NielsenOptions
+        options?: NielsenOptions,
+        configuration?: NielsenConfiguration
     ) {
         this.player = player;
-        this.nSdkInstance = loadNielsenLibrary(appId, instanceName, options, configuration.country);
+        this.dcrEnabled = configuration?.enableDCR ?? false;
+        this.dtvrEnabled = configuration?.enableDTVR ?? true;
+        this.country = configuration?.country ?? NielsenCountry.US;
+        this.nSdkInstance = loadNielsenLibrary(appId, instanceName, options, this.country);
 
         this.addEventListeners();
     }

--- a/nielsen/src/integration/NielsenHandler.ts
+++ b/nielsen/src/integration/NielsenHandler.ts
@@ -235,7 +235,7 @@ export class NielsenHandler {
     };
 
     private onAdBegin = ({ ad }: AdEvent<'adbegin'>) => {
-        const currentAd = this.player.ads!.currentAds.filter((ad: Ad) => ad.type === 'linear'); // TODO check why we chose to not use the ad from the event payload
+        if (ad.type !== 'linear') return;
         const { adBreak } = ad;
         const { timeOffset } = adBreak;
         const offset = this.player.ads?.dai?.contentTimeForStreamTime(timeOffset) ?? timeOffset;
@@ -249,7 +249,7 @@ export class NielsenHandler {
             this.nSdkInstance.ggPM('loadMetadata', dtvrAdMetadata);
         }
         if (this.dcrEnabled) {
-            const dcrAdMetadata = buildDCRAdMetadata(currentAd[0], this.country, this.duration);
+            const dcrAdMetadata = buildDCRAdMetadata(ad, this.country, this.duration);
             this.nSdkInstance.ggPM('loadMetadata', dcrAdMetadata);
         }
     };

--- a/nielsen/src/integration/NielsenHandler.ts
+++ b/nielsen/src/integration/NielsenHandler.ts
@@ -62,12 +62,10 @@ export class NielsenHandler {
                 const { type, vidtype, assetid, ...updateableParameters } = metadata;
                 console.log(`[NIELSEN] updateMetadata: ${{ type, vidtype, assetid }} will not be updated`);
                 this.nSdkInstance.ggPM('updateMetadata', updateableParameters);
-                // ex
                 break;
             }
             case NielsenCountry.CZ:
             default:
-            //
         }
     }
 

--- a/nielsen/src/integration/NielsenHandler.ts
+++ b/nielsen/src/integration/NielsenHandler.ts
@@ -78,6 +78,8 @@ export class NielsenHandler {
 
     private addEventListeners(): void {
         this.player.addEventListener('play', this.onPlay);
+        this.player.addEventListener('pause', this.onInterrupt);
+        this.player.addEventListener('waiting', this.onInterrupt);
         this.player.addEventListener('ended', this.onEnd);
         this.player.addEventListener('sourcechange', this.onSourceChange);
         this.player.addEventListener('volumechange', this.onVolumeChange);
@@ -98,6 +100,8 @@ export class NielsenHandler {
 
     private removeEventListeners(): void {
         this.player.removeEventListener('play', this.onPlay);
+        this.player.removeEventListener('pause', this.onInterrupt);
+        this.player.removeEventListener('waiting', this.onInterrupt);
         this.player.removeEventListener('ended', this.onEnd);
         this.player.removeEventListener('sourcechange', this.onSourceChange);
         this.player.removeEventListener('volumechange', this.onVolumeChange);
@@ -118,6 +122,11 @@ export class NielsenHandler {
 
     private onPlay = () => {
         this.maybeSendPlayEvent();
+    };
+
+    private onInterrupt = () => {
+        if (!this.dcrEnabled) return;
+        this.nSdkInstance.ggPM('stop', this.getPlayHeadPosition());
     };
 
     private onEnd = () => {

--- a/nielsen/src/integration/NielsenHandler.ts
+++ b/nielsen/src/integration/NielsenHandler.ts
@@ -7,7 +7,7 @@ import type {
     VolumeChangeEvent
 } from 'theoplayer';
 import { loadNielsenLibrary } from '../nielsen/NOLBUNDLE';
-import { AdMetadata, DTVRContentMetadata, NielsenOptions } from '../nielsen/Types';
+import { AdMetadata, DTVRContentMetadata, NielsenConfiguration, NielsenOptions } from '../nielsen/Types';
 import { getAdType } from '../utils/Util';
 
 const EMSG_PRIV_SUFFIX = 'PRIV{';
@@ -24,9 +24,15 @@ export class NielsenHandler {
 
     private decoder = new TextDecoder('utf-8');
 
-    constructor(player: ChromelessPlayer, appId: string, instanceName: string, options?: NielsenOptions) {
+    constructor(
+        player: ChromelessPlayer,
+        appId: string,
+        instanceName: string,
+        configuration: NielsenConfiguration,
+        options?: NielsenOptions
+    ) {
         this.player = player;
-        this.nSdkInstance = loadNielsenLibrary(appId, instanceName, options);
+        this.nSdkInstance = loadNielsenLibrary(appId, instanceName, options, configuration.country);
 
         this.addEventListeners();
     }

--- a/nielsen/src/nielsen/NOLBUNDLE.ts
+++ b/nielsen/src/nielsen/NOLBUNDLE.ts
@@ -8,6 +8,8 @@ export function loadNielsenLibrary(
     country?: NielsenCountry
 ) {
     if (country == NielsenCountry.CZ) {
+        // https://engineeringportal.nielsen.com/wiki/DCR_Czech_Video_Browser_SDK
+        // Step 1: Configure SDK
         // @ts-ignore
         !(function (e: any, n: any) {
             function t(e: any) {

--- a/nielsen/src/nielsen/NOLBUNDLE.ts
+++ b/nielsen/src/nielsen/NOLBUNDLE.ts
@@ -1,40 +1,102 @@
 /* eslint-disable */
-import { NielsenOptions } from './Types';
+import { NielsenCountry, NielsenOptions } from './Types';
 
-export function loadNielsenLibrary(appId: string, instanceName: string, options?: NielsenOptions) {
-    // https://engineeringportal.nielsen.com/docs/DTVR_Browser_SDK
-    // Add Static Queue Snippet to initialize a Nielsen SDK Instance.
-    // @ts-ignore
-    !(function (t: Window, n: any) {
-        t[n] = t[n] || {
-            nlsQ: function (e: any, o: any, c?: any, r?: any, s?: any, i?: any) {
-                // @ts-ignore
-                return (
-                    (s = t.document),
-                    (r = s.createElement('script')),
-                    (r.async = 1),
-                    (r.src =
-                        ('http:' === t.location.protocol ? 'http:' : 'https:') +
-                        '//cdn-gl.imrworldwide.com/conf/' +
-                        e +
-                        '.js#name=' +
-                        o +
-                        '&ns=' +
-                        n),
-                    (i = s.getElementsByTagName('script')[0]),
-                    i.parentNode.insertBefore(r, i),
-                    (t[n][o] = t[n][o] || {
-                        g: c || {},
-                        ggPM: function (e: any, c: any, r?: any, s?: any, i?: any) {
-                            // @ts-ignore
-                            (t[n][o].q = t[n][o].q || []).push([e, c, r, s, i]);
-                        }
-                    }),
-                    t[n][o]
-                );
+export function loadNielsenLibrary(
+    appId: string,
+    instanceName: string,
+    options?: NielsenOptions,
+    country?: NielsenCountry
+) {
+    if (country == NielsenCountry.CZ) {
+        // @ts-ignore
+        !(function (e: any, n: any) {
+            function t(e: any) {
+                return 'object' == typeof e ? JSON.parse(JSON.stringify(e)) : e;
             }
-        };
-    })(window, 'NOLBUNDLE');
+            e[n] = e[n] || {
+                nlsQ: function (o: any, r: any, c: any) {
+                    //@ts-ignore
+                    var s = e.document,
+                        a = s.createElement('script');
+                    (a.async = 1),
+                        (a.src =
+                            ('http:' === e.location.protocol ? 'http:' : 'https:') +
+                            '//cdn-gl.imrworldwide.com/conf/' +
+                            o +
+                            '.js#name=' +
+                            r +
+                            '&ns=' +
+                            n);
+                    var i = s.getElementsByTagName('script')[0];
+                    return (
+                        i.parentNode.insertBefore(a, i),
+                        (e[n][r] = e[n][r] || {
+                            g: c || {},
+                            ggPM: function (o: any, c: any, s: any, a: any, i: any) {
+                                // @ts-ignore
+                                e[n][r].q = e[n][r].q || [];
+                                try {
+                                    var l = t([o, c, s, a, i]);
+                                    e[n][r].q.push(l);
+                                } catch (e) {
+                                    console &&
+                                        console.log &&
+                                        console.log('Error: Cannot register event in Nielsen SDK queue.');
+                                }
+                            },
+                            trackEvent: function (o: any) {
+                                // @ts-ignore
+                                e[n][r].te = e[n][r].te || [];
+                                try {
+                                    var c = t(o);
+                                    e[n][r].te.push(c);
+                                } catch (e) {
+                                    console &&
+                                        console.log &&
+                                        console.log('Error: Cannot register event in Nielsen SDK queue.');
+                                }
+                            }
+                        }),
+                        e[n][r]
+                    );
+                }
+            };
+        })(window, 'NOLBUNDLE');
+    } else {
+        // https://engineeringportal.nielsen.com/docs/DTVR_Browser_SDK
+        // Add Static Queue Snippet to initialize a Nielsen SDK Instance.
+        // @ts-ignore
+        !(function (t: Window, n: any) {
+            t[n] = t[n] || {
+                nlsQ: function (e: any, o: any, c?: any, r?: any, s?: any, i?: any) {
+                    // @ts-ignore
+                    return (
+                        (s = t.document),
+                        (r = s.createElement('script')),
+                        (r.async = 1),
+                        (r.src =
+                            ('http:' === t.location.protocol ? 'http:' : 'https:') +
+                            '//cdn-gl.imrworldwide.com/conf/' +
+                            e +
+                            '.js#name=' +
+                            o +
+                            '&ns=' +
+                            n),
+                        (i = s.getElementsByTagName('script')[0]),
+                        i.parentNode.insertBefore(r, i),
+                        (t[n][o] = t[n][o] || {
+                            g: c || {},
+                            ggPM: function (e: any, c: any, r?: any, s?: any, i?: any) {
+                                // @ts-ignore
+                                (t[n][o].q = t[n][o].q || []).push([e, c, r, s, i]);
+                            }
+                        }),
+                        t[n][o]
+                    );
+                }
+            };
+        })(window, 'NOLBUNDLE');
+    }
 
     if (options) {
         return (window as any).NOLBUNDLE.nlsQ(appId, instanceName, options);

--- a/nielsen/src/nielsen/Types.ts
+++ b/nielsen/src/nielsen/Types.ts
@@ -116,6 +116,29 @@ export type AdMetadata = {
     assetid: any; // TODO string? or can be anything?
 } & { [key: string]: string };
 
+export type DCRAdMetadataCZ = AdMetadata & {
+    /*
+     * An item in the CMS tag reserved for an identifier enabling the connection of an advertisement description from the RTVK system, similarly to PEM TV data.
+     */
+    c4: string;
+    /*
+     * More detailed categorization of video content
+     */
+    c5: string;
+    /*
+     * Ad type (same value as in the "type" item)
+     */
+    c6: string;
+    /*
+     * Ad description. Possible use for cases where the AKA code is not available. RTB - designation of the advertising supplier (e.g. if there is no AKA code or more detailed description of the advertisement).
+     */
+    title?: string;
+    /*
+     * Length of broadcast ad in seconds. (So that the length indicator is available even in cases where the AKA code is not available.)
+     */
+    length: number;
+};
+
 /*
  * Countries for which (1) Nielsen provides DCR Browser SDKs and (2) the corresponding SDK was tested with this integration.
  */

--- a/nielsen/src/nielsen/Types.ts
+++ b/nielsen/src/nielsen/Types.ts
@@ -126,15 +126,15 @@ export type DCRAdMetadataCZ = AdMetadata & {
     /*
      * An item in the CMS tag reserved for an identifier enabling the connection of an advertisement description from the RTVK system, similarly to PEM TV data.
      */
-    c4: string;
+    nol_c4: string;
     /*
      * More detailed categorization of video content
      */
-    c5: string;
+    nol_c5: string;
     /*
      * Ad type (same value as in the "type" item)
      */
-    c6: string;
+    nol_c6: string;
     /*
      * Ad description. Possible use for cases where the AKA code is not available. RTB - designation of the advertising supplier (e.g. if there is no AKA code or more detailed description of the advertisement).
      */
@@ -142,7 +142,7 @@ export type DCRAdMetadataCZ = AdMetadata & {
     /*
      * Length of broadcast ad in seconds. (So that the length indicator is available even in cases where the AKA code is not available.)
      */
-    length: number;
+    length: string;
 };
 
 /*

--- a/nielsen/src/nielsen/Types.ts
+++ b/nielsen/src/nielsen/Types.ts
@@ -14,7 +14,7 @@ export type NielsenOptions = {
 /**
  * adModel: 1) - Linear – matches TV ad load * 2) Dynamic – Dynamic Ad Insertion (DAI)
  */
-export type ContentMetadata = {
+export type DTVRContentMetadata = {
     type: 'content';
     adModel: '1' | '2';
 } & { [key: string]: string };

--- a/nielsen/src/nielsen/Types.ts
+++ b/nielsen/src/nielsen/Types.ts
@@ -1,5 +1,11 @@
 export type AdType = 'preroll' | 'midroll' | 'postroll' | 'ad';
 
+export type NielsenConfiguration = {
+    country: NielsenCountry;
+    enableDTVR: boolean;
+    enableDCR: boolean;
+};
+
 export type NielsenOptions = {
     // HTML DOM element id of the player container
     containerId?: string;

--- a/nielsen/src/nielsen/Types.ts
+++ b/nielsen/src/nielsen/Types.ts
@@ -21,7 +21,7 @@ export type DCRContentMetadata = {
     /*
      * A fixed dial specifying the type of measured content
      */
-    type: 'content';
+    type: string;
     /*
      * Unique identifier for the video content (video file). Any label according to the needs of the TV company, which will ensure the identification of the same content across platforms. It can also be used for chaining several pieces of information from internal systems. At the beginning, the possibility of adding a client ID (to ensure uniqueness across clients)
      */
@@ -49,11 +49,11 @@ export type DCRContentMetadata = {
     /*
      * Indication of whether the video content being played is the entire episode or only part of it. Always use 'y' for live.
      */
-    isfullepisode: 'y' | 'n';
+    isfullepisode: string;
     /*
      * CMS tag helper item. The method of recording ads insertion: 1. Linear – corresponds to TV insertion of ads 2. Dynamic – Dynamic Ad Insertion (DAI)
      */
-    adloadtype: '1' | '2';
+    adloadtype: string;
 };
 
 export enum AdLoadType {
@@ -166,6 +166,26 @@ export type DCRContentMetadataCZ = DCRContentMetadata & {
      * CMS tag helper item. Indication of whether the content being played supports the insertion of advertisements. “0” – No ads “1” – Supports ads “2” – Don't know (default).
      */
     hasAds: '0' | '1' | '2';
+};
+
+export type NielsenDCRContentMetadataUS = NielsenDCRContentMetadata & {
+    /*
+     * Gracenote TMS ID (If available) should be passed for all telecasted content for clients using the Gracenote solution for proper matching purposes
+     * Note: The TMS ID will be a 14 character string. Normally leading with 2 alpha characters ('EP', 'MV', 'SH' or 'SP'), followed by 12 numbers. This should be provided to you by Nielsen
+     */
+    crossId1?: string;
+    /*
+     * Populated by content distributor to contribute viewing from that distributor to the given content originator. For a full list of acceptable values, please contact your Nielsen representative.
+     */
+    crossId2?: string;
+    /*
+     * One of two custom segments for clients' granular reporting within a brand. (Examples: Genre - horror, comedy, etc. ; Timeslot - primetime, daytime, etc. ; News type - breakingnews, weather, etc.)
+     */
+    segB?: string;
+    /*
+     * One of two custom segments for clients' granular reporting within a brand. (Examples: Genre - horror, comedy, etc. ; Timeslot - primetime, daytime, etc. ; News type - breakingnews, weather, etc.)
+     */
+    segC?: string;
 };
 
 export type DCRContentMetadataUS = DCRContentMetadata & {

--- a/nielsen/src/nielsen/Types.ts
+++ b/nielsen/src/nielsen/Types.ts
@@ -11,6 +11,98 @@ export type NielsenOptions = {
     optout?: boolean;
 };
 
+export type DCRContentMetadata = {
+    /*
+     * A fixed dial specifying the type of measured content
+     */
+    type: 'content';
+    /*
+     * Unique identifier for the video content (video file). Any label according to the needs of the TV company, which will ensure the identification of the same content across platforms. It can also be used for chaining several pieces of information from internal systems. At the beginning, the possibility of adding a client ID (to ensure uniqueness across clients)
+     */
+    assetid: string;
+    /*
+     * Content description (name of the show, channel name, etc.)
+     */
+    program: string;
+    /*
+     * Detailed description of content.
+     * [VOD] episode title
+     * [LIVE] name of the program (if it is available and can be dynamically changed along with the change of the program. Otherwise, fill in only the name of the channel))
+     */
+    title: string;
+    /*
+     * The length of the broadcast video content. It is also used to uniquely distinguish VOD and live broadcasts. This is the length of the currently playing content/file. If the content is, for example, only a part of the program, the length of this played part of the program is indicated. Use 86400 for live content.
+     */
+    length: string;
+    /*
+     * Broadcast date, if you cannot fill in the correct value, please use the constant "19700101 00:00:01".
+     * [VOD] The date and time the video content was exposed online YYYYMMDD HH24:MI:SS.
+     * [LIVE] Midnight of the current day in YYYYMMDD 00:00:00 format
+     */
+    airdate: string;
+    /*
+     * Indication of whether the video content being played is the entire episode or only part of it. Always use 'y' for live.
+     */
+    isfullepisode: 'y' | 'n';
+    /*
+     * CMS tag helper item. The method of recording ads insertion: 1. Linear – corresponds to TV insertion of ads 2. Dynamic – Dynamic Ad Insertion (DAI)
+     */
+    adloadtype: '1' | '2';
+};
+
+export type DCRContentMetadataCZ = DCRContentMetadata & {
+    /*
+     * IDEC type identifier
+     */
+    crossId1: string;
+    /*
+     * More detailed categorization of video content.
+     * [VOD] Program type (codes according to the TV code list).
+     * [LIVE] The program type of the content being played, if available and can be changed dynamically with the program change. Otherwise, send an empty string.
+     */
+    segB: string;
+    /*
+     * More detailed categorization of video content. Should always be an empty string.
+     */
+    segC: '';
+    /*
+     * Live TV station code
+     * [VOD] Keep this empty and pass "nol_c1":"p1,".
+     * [LIVE] implementation : "nol_c1":"p1,value" where value = Live station code used in the output data of the TV audience measurement project. see current appendix of the reference manual "Appendix RP 13 - List of stations.xlsx" If the live broadcast does not correspond to any TV station, use the code 9999.
+     */
+    c1: string;
+    /*
+     * TV Identity for VOD.
+     * [VOD] Pass "nol_c2" : "p2,value" where value = To ensure the best possible harmonization of PEM D online measurement data with the data of the TV meter project, it is recommended to use TV IDENT as another online content identifier. If TVIDENT is not available at the time the content is brought online, c2 remains blank (and can be filled in later). TVIdent - same as in broadcast protocols of TV stations.
+     * [LIVE] Keep empty : "nol_c2":"p2,"
+     */
+    c2?: string;
+    /*
+     * CMS tag helper item. Indication of whether the content being played supports the insertion of advertisements. “0” – No ads “1” – Supports ads “2” – Don't know (default).
+     */
+    hasAds: '0' | '1' | '2';
+};
+
+export type DCRContentMetadataUS = DCRContentMetadata & {
+    /*
+     * Gracenote TMS ID (If available) should be passed for all telecasted content for clients using the Gracenote solution for proper matching purposes
+     * Note: The TMS ID will be a 14 character string. Normally leading with 2 alpha characters ('EP', 'MV', 'SH' or 'SP'), followed by 12 numbers. This should be provided to you by Nielsen
+     */
+    crossId1?: string;
+    /*
+     * Populated by content distributor to contribute viewing from that distributor to the given content originator. For a full list of acceptable values, please contact your Nielsen representative.
+     */
+    crossId2?: string;
+    /*
+     * One of two custom segments for clients' granular reporting within a brand. (Examples: Genre - horror, comedy, etc. ; Timeslot - primetime, daytime, etc. ; News type - breakingnews, weather, etc.)
+     */
+    segB?: string;
+    /*
+     * One of two custom segments for clients' granular reporting within a brand. (Examples: Genre - horror, comedy, etc. ; Timeslot - primetime, daytime, etc. ; News type - breakingnews, weather, etc.)
+     */
+    segC?: string;
+};
+
 /**
  * adModel: 1) - Linear – matches TV ad load * 2) Dynamic – Dynamic Ad Insertion (DAI)
  */

--- a/nielsen/src/nielsen/Types.ts
+++ b/nielsen/src/nielsen/Types.ts
@@ -56,6 +56,85 @@ export type DCRContentMetadata = {
     adloadtype: '1' | '2';
 };
 
+export enum AdLoadType {
+    linear = '1',
+    dynamic = '2'
+}
+
+export type NielsenDCRContentMetadata = {
+    /*
+     * Unique identifier for the video content (video file). Any label according to the needs of the TV company, which will ensure the identification of the same content across platforms. It can also be used for chaining several pieces of information from internal systems. At the beginning, the possibility of adding a client ID (to ensure uniqueness across clients)
+     */
+    assetid: string;
+    /*
+     * Content description (name of the show, channel name, etc.)
+     */
+    program: string;
+    /*
+     * Detailed description of content.
+     * [VOD] episode title
+     * [LIVE] name of the program (if it is available and can be dynamically changed along with the change of the program. Otherwise, fill in only the name of the channel))
+     */
+    title: string;
+    /*
+     * The length of the broadcast video content. It is also used to uniquely distinguish VOD and live broadcasts. This is the length of the currently playing content/file. If the content is, for example, only a part of the program, the length of this played part of the program is indicated. Use 86400 for live content.
+     */
+    length: string;
+    /*
+     * Broadcast date, if left empty, "19700101 00:00:01" will be reported.
+     * [VOD] The date and time the video content was exposed online YYYYMMDD HH24:MI:SS.
+     * [LIVE] Midnight of the current day in YYYYMMDD 00:00:00 format
+     */
+    airdate?: string;
+    /*
+     * Indication of whether the video content being played is the entire episode or only part of it. Always reported as true for live.
+     */
+    isfullepisode: boolean;
+    /*
+     * CMS tag helper item. The method of recording ads insertion: 1. Linear – corresponds to TV insertion of ads 2. Dynamic – Dynamic Ad Insertion (DAI)
+     */
+    adloadtype: AdLoadType;
+};
+
+export enum HasAds {
+    no_ads = '0',
+    supports_ads = '1',
+    unknown = '2'
+}
+
+export type NielsenDCRContentMetadataCZ = NielsenDCRContentMetadata & {
+    /*
+     * IDEC type identifier
+     */
+    crossId1: string;
+    /*
+     * More detailed categorization of video content.
+     * [VOD] Program type (codes according to the TV code list).
+     * [LIVE] The program type of the content being played, if available and can be changed dynamically with the program change. Otherwise, send an empty string.
+     */
+    segB: string;
+    /*
+     * More detailed categorization of video content.
+     */
+    segC?: '';
+    /*
+     * Live TV station code
+     * [VOD] Keep this empty and pass "nol_c1":"p1,".
+     * [LIVE] implementation : "nol_c1":"p1,value" where value = Live station code used in the output data of the TV audience measurement project. see current appendix of the reference manual "Appendix RP 13 - List of stations.xlsx" If the live broadcast does not correspond to any TV station, use the code 9999.
+     */
+    c1?: string;
+    /*
+     * TV Identity for VOD.
+     * [VOD] Pass "nol_c2" : "p2,value" where value = To ensure the best possible harmonization of PEM D online measurement data with the data of the TV meter project, it is recommended to use TV IDENT as another online content identifier. If TVIDENT is not available at the time the content is brought online, c2 remains blank (and can be filled in later). TVIdent - same as in broadcast protocols of TV stations.
+     * [LIVE] Keep empty : "nol_c2":"p2,"
+     */
+    c2?: string;
+    /*
+     * CMS tag helper item. Indication of whether the content being played supports the insertion of advertisements. “0” – No ads “1” – Supports ads “2” – Don't know (default).
+     */
+    hasAds: HasAds;
+};
+
 export type DCRContentMetadataCZ = DCRContentMetadata & {
     /*
      * IDEC type identifier
@@ -68,7 +147,7 @@ export type DCRContentMetadataCZ = DCRContentMetadata & {
      */
     segB: string;
     /*
-     * More detailed categorization of video content. Should always be an empty string.
+     * More detailed categorization of video content.
      */
     segC: '';
     /*
@@ -76,13 +155,13 @@ export type DCRContentMetadataCZ = DCRContentMetadata & {
      * [VOD] Keep this empty and pass "nol_c1":"p1,".
      * [LIVE] implementation : "nol_c1":"p1,value" where value = Live station code used in the output data of the TV audience measurement project. see current appendix of the reference manual "Appendix RP 13 - List of stations.xlsx" If the live broadcast does not correspond to any TV station, use the code 9999.
      */
-    c1: string;
+    nol_c1?: string;
     /*
      * TV Identity for VOD.
      * [VOD] Pass "nol_c2" : "p2,value" where value = To ensure the best possible harmonization of PEM D online measurement data with the data of the TV meter project, it is recommended to use TV IDENT as another online content identifier. If TVIDENT is not available at the time the content is brought online, c2 remains blank (and can be filled in later). TVIdent - same as in broadcast protocols of TV stations.
      * [LIVE] Keep empty : "nol_c2":"p2,"
      */
-    c2?: string;
+    nol_c2?: string;
     /*
      * CMS tag helper item. Indication of whether the content being played supports the insertion of advertisements. “0” – No ads “1” – Supports ads “2” – Don't know (default).
      */

--- a/nielsen/src/nielsen/Types.ts
+++ b/nielsen/src/nielsen/Types.ts
@@ -23,3 +23,11 @@ export type AdMetadata = {
     type: AdType;
     assetid: any; // TODO string? or can be anything?
 } & { [key: string]: string };
+
+/*
+ * Countries for which (1) Nielsen provides DCR Browser SDKs and (2) the corresponding SDK was tested with this integration.
+ */
+export enum NielsenCountry {
+    US = 'US',
+    CZ = 'CZ'
+}

--- a/nielsen/src/utils/Util.ts
+++ b/nielsen/src/utils/Util.ts
@@ -1,5 +1,5 @@
-import type { AdBreak } from 'theoplayer';
-import { AdType } from '../nielsen/Types';
+import type { Ad, AdBreak, GoogleImaAd } from 'theoplayer';
+import { AdMetadata, AdType, DCRAdMetadataCZ, NielsenCountry } from '../nielsen/Types';
 
 export function getAdType(adBreak: AdBreak): AdType {
     const currentAdBreakTimeOffset = adBreak.timeOffset;
@@ -12,4 +12,30 @@ export function getAdType(adBreak: AdBreak): AdType {
         currentAdBreakPosition = 'midroll';
     }
     return currentAdBreakPosition;
+}
+
+export function buildDCRAdMetadata(ad: Ad, country: NielsenCountry): AdMetadata {
+    const adMetadata = {
+        assetid: ad.id ?? '',
+        type: getAdType(ad.adBreak)
+    };
+    if (country == NielsenCountry.US) {
+        return adMetadata;
+    }
+    if (country == NielsenCountry.CZ) {
+        const dcrAdMetadataCZ: DCRAdMetadataCZ = {
+            ...adMetadata,
+            ['nol_c4']: 'PLACEHOLDER',
+            ['nol_c5']: '2', // 1. regular show, 2. advertising, 3. trailer, 4. divide, 5. komerce (teleshopping,sponsor) TODO: provide API to control this
+            ['nol_c6']: `p6,${adMetadata.type}`,
+            title: (ad as GoogleImaAd).title ?? '',
+            length: ad.duration?.toString() ?? '0'
+        };
+        return dcrAdMetadataCZ;
+    }
+    console.error('[NIELSEN - Error] Failed to extract Ad Metadata - sending placeholders instead');
+    return {
+        type: 'ad',
+        assetid: '0000'
+    };
 }

--- a/nielsen/src/utils/Util.ts
+++ b/nielsen/src/utils/Util.ts
@@ -15,10 +15,10 @@ export function getAdType(offset: number, duration: number): AdType {
     return currentAdBreakPosition;
 }
 
-export function buildDCRAdMetadata(ad: Ad, country: NielsenCountry): AdMetadata {
+export function buildDCRAdMetadata(ad: Ad, country: NielsenCountry, duration: number): AdMetadata {
     const adMetadata = {
         assetid: ad.id ?? '',
-        type: getAdType(ad.adBreak)
+        type: getAdType(ad.adBreak.timeOffset, duration)
     };
     if (country == NielsenCountry.US) {
         return adMetadata;

--- a/nielsen/src/utils/Util.ts
+++ b/nielsen/src/utils/Util.ts
@@ -1,14 +1,15 @@
 import type { Ad, AdBreak, GoogleImaAd } from 'theoplayer';
 import { AdMetadata, AdType, DCRAdMetadataCZ, NielsenCountry } from '../nielsen/Types';
 
-export function getAdType(adBreak: AdBreak): AdType {
-    const currentAdBreakTimeOffset = adBreak.timeOffset;
+export function getAdType(offset: number, duration: number): AdType {
     let currentAdBreakPosition: AdType = 'ad';
-    if (currentAdBreakTimeOffset === 0) {
+    if (offset === 0) {
         currentAdBreakPosition = 'preroll';
-    } else if (currentAdBreakTimeOffset < 0) {
+    } else if (offset < 0) {
         currentAdBreakPosition = 'postroll';
-    } else if (currentAdBreakTimeOffset > 0) {
+    } else if (duration - offset < 1) {
+        currentAdBreakPosition = 'postroll'; // For DAI ads, the offset and duration will be converted from stream time to content time and coincide more or less
+    } else if (offset > 0) {
         currentAdBreakPosition = 'midroll';
     }
     return currentAdBreakPosition;

--- a/nielsen/src/utils/Util.ts
+++ b/nielsen/src/utils/Util.ts
@@ -33,9 +33,6 @@ export function buildDCRAdMetadata(ad: Ad, country: NielsenCountry): AdMetadata 
         };
         return dcrAdMetadataCZ;
     }
-    console.error('[NIELSEN - Error] Failed to extract Ad Metadata - sending placeholders instead');
-    return {
-        type: 'ad',
-        assetid: '0000'
-    };
+    console.error('[NIELSEN - Error] No NielsenCountry was provided - sending only assetid and type');
+    return adMetadata;
 }

--- a/nielsen/test/pages/main.html
+++ b/nielsen/test/pages/main.html
@@ -15,7 +15,7 @@
                 ui: {
                     fluid: true
                 },
-                libraryLocation: "/node_modules/theoplayer/"
+                libraryLocation: "./../../../node_modules/theoplayer/"
             });
 
             //

--- a/nielsen/test/pages/main.html
+++ b/nielsen/test/pages/main.html
@@ -3,9 +3,9 @@
     <head>
         <meta charset="UTF-8" />
         <title>Connector test page</title>
-        <link rel="stylesheet" type="text/css" href="/node_modules/theoplayer/ui.css" />
-        <script src="/node_modules/theoplayer/THEOplayer.js"></script>
-        <script src="/dist/nielsen-connector.umd.js"></script>
+        <link rel="stylesheet" type="text/css" href="./../../../node_modules/theoplayer/ui.css" />
+        <script src="./../../../node_modules/theoplayer/THEOplayer.js"></script>
+        <script src="./../../dist/nielsen-connector.umd.js"></script>
     </head>
     <body>
         <div id="THEOplayer" class="theoplayer-container video-js theoplayer-skin"></div>

--- a/nielsen/test/pages/main.html
+++ b/nielsen/test/pages/main.html
@@ -21,7 +21,7 @@
             //
             // Add your connector setup logic here
             //
-            const appId = "P77E3B909-D4B5-4E5C-9B5F-77B0E8FE27F5";
+            const appId = "XXXXXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXX";
             const instanceName = "instanceName";
             const options = {
                 // containerId: 'THEOplayer',

--- a/nielsen/test/pages/main.html
+++ b/nielsen/test/pages/main.html
@@ -23,6 +23,22 @@
             //
             const appId = "XXXXXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXX";
             const instanceName = "instanceName";
+            const contentMetadataObjectCZ = {
+                "assetid": "cz-500358-98731568435405",
+                "type": "content",
+                "program": "Animated Test Content",
+                "title": "Big Buck Bunny",
+                "length": "596",
+                "airdate": "20230620 20:00:00",
+                "isfullepisode": "y",
+                "crossId1": "915 954 39504",
+                "nol_c1": "p1,",
+                "nol_c2": "p2, 651678089925925",
+                "segB": "011",
+                "segC": "",
+                "adloadtype": "2",
+                "hasAds": "1"
+                };
             const options = {
                 // containerId: 'THEOplayer',
                 nol_sdkDebug: "debug"


### PR DESCRIPTION
Add DCR support for US and International (CZ) SDKs

The connector by default serves as a DTVR integration (US), as it did before this PR. You can now pass a NielsenConfiguration to the constructor of NielsenConnector where you specify which functionality you need. E.g. For the Czech Republic DCR integration, initialize the connector as follows:

```js
const configuration = {
    country: "CZ",
    enableDTVR: false,
    enableDCR: true
}
const nielsenConnector = new THEOplayerNielsenConnector.NielsenConnector(
    player,
    "XXXXXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXX",
    "exampleInstanceName",
    options,
    configuration
);
```

The focus was on the Czech Republic DCR implementation for this PR. You can find the documentation [here](https://nielsensdk.admosphere.cz/index.html) and on the [Nielsen engineering portal](https://engineeringportal.nielsen.com/wiki/DCR_Czech_Video_Browser_SDK). However, a Nielsen representative pointed out that the main differences between the DCR implementations are mainly in the metadata requirements, so typings and helper functions to build metadata for US based customers have also been included. Note that also the static queue snippet differs per configured country's documentation. This is also reflected in this integration.

The existing DTVR functionality should have remained intact, but is now behind configuration flags. Note that some small changes have been made that impact DTVR too:

- updateMetadata reporting was modified to prevent updating of the values for `type`, `vidtype`, or `assetid` parameters , as per the [documentation](https://engineeringportal.nielsen.com/wiki/updateMetadata_(Browser)) on this event
- in the `adbegin` listener, the current ad is retrieved through the event playload instead of the Ads API
- detection of postrolls in DAI sources was added