### PR TITLE
Bugfix/missing c4 parameter

### DIFF
--- a/.changeset/fresh-turkeys-hang.md
+++ b/.changeset/fresh-turkeys-hang.md
@@ -1,0 +1,5 @@
+---
+"@theoplayer/nielsen-connector-web": minor
+---
+
+Added an optional c4 parameter to `NielsenDCRContentMetadataCZ`.

--- a/nielsen/src/nielsen/Types.ts
+++ b/nielsen/src/nielsen/Types.ts
@@ -130,6 +130,12 @@ export type NielsenDCRContentMetadataCZ = NielsenDCRContentMetadata & {
      */
     c2?: string;
     /*
+     * The actual duration of the live broadcast
+     * [VOD] Keep empty
+     * [LIVE] Pass the duration of the live broadcast in seconds
+     */
+    c4?: string;
+    /*
      * CMS tag helper item. Indication of whether the content being played supports the insertion of advertisements. “0” – No ads “1” – Supports ads “2” – Don't know (default).
      */
     hasAds: HasAds;
@@ -162,6 +168,12 @@ export type DCRContentMetadataCZ = DCRContentMetadata & {
      * [LIVE] Keep empty : "nol_c2":"p2,"
      */
     nol_c2?: string;
+    /*
+     * The actual duration of the live broadcast
+     * [VOD] Keep empty
+     * [LIVE] Pass the value in seconds as follows "nol_c4" : "p4, value_in_seconds"
+     */
+    nol_c4?: string;
     /*
      * CMS tag helper item. Indication of whether the content being played supports the insertion of advertisements. “0” – No ads “1” – Supports ads “2” – Don't know (default).
      */

--- a/nielsen/src/nielsen/Types.ts
+++ b/nielsen/src/nielsen/Types.ts
@@ -171,7 +171,7 @@ export type DCRContentMetadataCZ = DCRContentMetadata & {
     /*
      * The actual duration of the live broadcast
      * [VOD] Keep empty
-     * [LIVE] Pass the value in seconds as follows "nol_c4" : "p4, value_in_seconds"
+     * [LIVE] Pass the value in seconds as follows "nol_c4" : "p4,value_in_seconds"
      */
     nol_c4?: string;
     /*

--- a/nielsen/src/utils/Util.ts
+++ b/nielsen/src/utils/Util.ts
@@ -45,13 +45,13 @@ export function buildDCRContentMetadata(
         const dcrContentMetadataCZ: DCRContentMetadataCZ = {
             ...dcrContentMetadata,
             ['crossId1']: crossId1,
+            ['nol_c1']: `p1,${c1 ?? ''}`,
             ['nol_c2']: `p2,${c2 ?? ''}`,
+            ['nol_c4']: `p4,${c4 ?? ''}`,
             segB: segB,
             segC: segC ?? '',
             hasAds: hasAds
         };
-        if (c1) dcrContentMetadataCZ['nol_c1'] = `p1,${c1}`;
-        if (c4) dcrContentMetadataCZ['nol_c4'] = `p4,${c4}`;
         return dcrContentMetadataCZ;
     }
     if (country === NielsenCountry.US) {

--- a/nielsen/src/utils/Util.ts
+++ b/nielsen/src/utils/Util.ts
@@ -41,7 +41,7 @@ export function buildDCRContentMetadata(
         adloadtype: metadata.adloadtype
     };
     if (country === NielsenCountry.CZ) {
-        const { crossId1, segB, segC, c1, c2, hasAds } = metadata as NielsenDCRContentMetadataCZ;
+        const { crossId1, segB, segC, c1, c2, c4, hasAds } = metadata as NielsenDCRContentMetadataCZ;
         const dcrContentMetadataCZ: DCRContentMetadataCZ = {
             ...dcrContentMetadata,
             ['crossId1']: crossId1,
@@ -51,6 +51,7 @@ export function buildDCRContentMetadata(
             hasAds: hasAds
         };
         if (c1) dcrContentMetadataCZ['nol_c1'] = `p1,${c1}`;
+        if (c4) dcrContentMetadataCZ['nol_c4'] = `p4,${c4}`;
         return dcrContentMetadataCZ;
     }
     if (country === NielsenCountry.US) {


### PR DESCRIPTION
Small PR to add a missing parameter to the Czech main content metadata properties. This was missed in the initial release since the parameter is not mentioned in the documentation on [Nielsen's Engineering Portal](https://engineeringportal.nielsen.com/wiki/Czech_SDK_Metadata). It is, however, mentioned on the [Admosphere documentation](https://nielsensdk.admosphere.cz/web/cz_metadata.html#:~:text=Ne-,c4,-Re%C3%A1ln%C3%A1%20d%C3%A9lka%20%C5%BEiv%C3%A9ho).