### PR TITLE
Bugfix/yospace missing ad events

### DIFF
--- a/.changeset/lovely-queens-boil.md
+++ b/.changeset/lovely-queens-boil.md
@@ -1,0 +1,5 @@
+---
+"@theoplayer/yospace-connector-web": minor
+---
+
+Create ad break from advert start, if missing

--- a/yospace/src/integration/YospaceAdHandler.ts
+++ b/yospace/src/integration/YospaceAdHandler.ts
@@ -145,7 +145,10 @@ export class YospaceAdHandler {
         }
 
         if (this.currentAdBreak === undefined) {
-            this.currentAdBreak = this.getOrCreateAdBreak(advert.broker.currentAdBreak, true);
+            const missingAdBreak = advert.broker.getAdBreakForAdvert(advert);
+            if (missingAdBreak !== undefined) {
+                this.currentAdBreak = this.getOrCreateAdBreak(missingAdBreak, true);
+            }
         }
 
         const ad = this.ads.get(advert);

--- a/yospace/src/integration/YospaceAdHandler.ts
+++ b/yospace/src/integration/YospaceAdHandler.ts
@@ -144,6 +144,10 @@ export class YospaceAdHandler {
             this.advertStartListener = undefined;
         }
 
+        if (this.currentAdBreak === undefined) {
+            this.currentAdBreak = this.getOrCreateAdBreak(advert.broker.currentAdBreak, true);
+        }
+
         const ad = this.ads.get(advert);
         if (ad !== undefined) {
             this.currentAd = ad;

--- a/yospace/src/yospace/AdBreak.ts
+++ b/yospace/src/yospace/AdBreak.ts
@@ -75,6 +75,7 @@ export interface AdvertEventHandler {
 
 export interface Advert extends AdvertEventHandler {
     addMacroSubstitution(key: string, value: string): void;
+    broker: Broker;
     getAdType(): string;
     getAdVerifications(): AdVerification[];
     getCompanionAdsByType(type: ResourceType): CompanionCreative[];
@@ -93,7 +94,10 @@ export interface Advert extends AdvertEventHandler {
     isActive(): boolean;
     isFiller(): boolean;
     isNonLinear(): boolean;
-    broker: any;
+}
+
+export interface Broker {
+    getAdBreakForAdvert(advert: Advert): AdBreak | undefined;
 }
 
 export type { Advert as AdVert };

--- a/yospace/src/yospace/AdBreak.ts
+++ b/yospace/src/yospace/AdBreak.ts
@@ -93,6 +93,7 @@ export interface Advert extends AdvertEventHandler {
     isActive(): boolean;
     isFiller(): boolean;
     isNonLinear(): boolean;
+    broker: any;
 }
 
 export type { Advert as AdVert };

--- a/yospace/src/yospace/AdBreak.ts
+++ b/yospace/src/yospace/AdBreak.ts
@@ -1,3 +1,5 @@
+import { YospaceSessionManager } from "./YospaceSessionManager";
+
 export enum ResourceType {
     STATIC,
     HTML,
@@ -75,7 +77,7 @@ export interface AdvertEventHandler {
 
 export interface Advert extends AdvertEventHandler {
     addMacroSubstitution(key: string, value: string): void;
-    broker: Broker;
+    broker: YospaceSessionManager;
     getAdType(): string;
     getAdVerifications(): AdVerification[];
     getCompanionAdsByType(type: ResourceType): CompanionCreative[];
@@ -94,10 +96,6 @@ export interface Advert extends AdvertEventHandler {
     isActive(): boolean;
     isFiller(): boolean;
     isNonLinear(): boolean;
-}
-
-export interface Broker {
-    getAdBreakForAdvert(advert: Advert): AdBreak | undefined;
 }
 
 export type { Advert as AdVert };

--- a/yospace/src/yospace/YospaceSessionManager.ts
+++ b/yospace/src/yospace/YospaceSessionManager.ts
@@ -1,6 +1,7 @@
 import { PlayerEvent } from './PlayerEvent';
 import { TimedMetadata } from './TimedMetadata';
 import { AnalyticEventObserver } from './AnalyticEventObserver';
+import { AdVert, AdBreak } from './AdBreak';
 
 export enum ResultCode {
     CONNECTION_ERROR = -1,
@@ -28,6 +29,8 @@ export type YospaceSessionManagerCreator = {
 };
 
 export interface YospaceSession {
+    getAdBreakForAdvert(advert: AdVert): AdBreak | undefined;
+
     getPlaybackMode(): PlaybackMode;
 
     getPlaybackUrl(): string;


### PR DESCRIPTION
This PR adds logic for creating an AdBreak from the Yospace AdvertStart event, if it is missing. This allows the specific ad events for THEOplayer to be fired.

This solves the case where a viewer joins a stream while an ad is playing, or when a preroll ad plays, but there was no AdvertBreakStart event fired, so the THEOplayer ad events were also missing for this advert break.