### PR TITLE
Fix Yospace types

### DIFF
--- a/.changeset/orange-boxes-fetch.md
+++ b/.changeset/orange-boxes-fetch.md
@@ -1,0 +1,5 @@
+---
+"@theoplayer/yospace-connector-web": patch
+---
+
+Require THEOplayer 8.1.0 or higher for correct TypeScript type definitions.

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "prettier": "^3.2.4",
         "rimraf": "^5.0.5",
         "rollup": "^4.14.0",
-        "theoplayer": "^7.12.0",
+        "theoplayer": "^8.3.0",
         "ts-jest": "^29.1.2",
         "ts-node": "^10.9.2",
         "tslib": "^2.6.2",
@@ -46,7 +46,7 @@
     },
     "adscript": {
       "name": "@theoplayer/adscript-connector-web",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "peerDependencies": {
         "theoplayer": "^7.0.0 || ^8.0.0"
@@ -54,7 +54,7 @@
     },
     "cmcd": {
       "name": "@theoplayer/cmcd-connector-web",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "license": "MIT",
       "peerDependencies": {
         "theoplayer": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -62,7 +62,7 @@
     },
     "comscore": {
       "name": "@theoplayer/comscore-connector-web",
-      "version": "1.0.21",
+      "version": "1.2.0",
       "license": "MIT",
       "peerDependencies": {
         "theoplayer": "^7.0.0 || ^8.0.0"
@@ -70,7 +70,7 @@
     },
     "conviva": {
       "name": "@theoplayer/conviva-connector-web",
-      "version": "2.1.4",
+      "version": "2.3.0",
       "license": "MIT",
       "devDependencies": {
         "@convivainc/conviva-js-coresdk": "^4.7.4"
@@ -88,7 +88,7 @@
     },
     "gemius": {
       "name": "@theoplayer/gemius-connector-web",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "peerDependencies": {
         "theoplayer": "^7.0.0 || ^8.0.0"
@@ -96,7 +96,7 @@
     },
     "nielsen": {
       "name": "@theoplayer/nielsen-connector-web",
-      "version": "1.2.0",
+      "version": "1.4.0",
       "license": "MIT",
       "peerDependencies": {
         "theoplayer": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -7880,9 +7880,10 @@
       "license": "MIT"
     },
     "node_modules/theoplayer": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/theoplayer/-/theoplayer-7.12.0.tgz",
-      "integrity": "sha512-Vikb20iermLQz0IZRnzwzuvzGTbpxxmIYXHJPuiwRGfP8EtaS43+94GPlxgMGYrFlvwXIa7zi1qFF+M/mCvTdQ=="
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/theoplayer/-/theoplayer-8.3.0.tgz",
+      "integrity": "sha512-KV9cpPQHVv8cvtt88lRCM+u+gXd64PlDmDq7Yqzcgkoy7RXisHqtiTdxnCO7U2zkMLNy4rM8WVnjWKZNrDbC0g==",
+      "license": "SEE LICENSE AT https://www.theoplayer.com/terms"
     },
     "node_modules/tmp": {
       "version": "0.0.33",
@@ -8763,7 +8764,7 @@
     },
     "yospace": {
       "name": "@theoplayer/yospace-connector-web",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "license": "MIT",
       "peerDependencies": {
         "theoplayer": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "prettier": "^3.2.4",
     "rimraf": "^5.0.5",
     "rollup": "^4.14.0",
-    "theoplayer": "^7.12.0",
+    "theoplayer": "^8.3.0",
     "ts-jest": "^29.1.2",
     "ts-node": "^10.9.2",
     "tslib": "^2.6.2",

--- a/typedoc.base.json
+++ b/typedoc.base.json
@@ -15,7 +15,7 @@
   "externalDocumentation": {
     "theoplayer": {
       "dtsPath": "~/THEOplayer.d.ts",
-      "externalBaseURL": "https://www.theoplayer.com/docs/theoplayer/v7/api-reference/web"
+      "externalBaseURL": "https://www.theoplayer.com/docs/theoplayer/v8/api-reference/web"
     }
   }
 }

--- a/yospace/package.json
+++ b/yospace/package.json
@@ -42,7 +42,7 @@
     "package.json"
   ],
   "peerDependencies": {
-    "theoplayer": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+    "theoplayer": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.1.0"
   },
   "directories": {
     "test": "test"

--- a/yospace/src/integration/YospaceManager.ts
+++ b/yospace/src/integration/YospaceManager.ts
@@ -2,10 +2,9 @@ import type {
     ChromelessPlayer,
     ServerSideAdIntegrationController,
     ServerSideAdIntegrationHandler,
-    SourceDescription,
-    YospaceTypedSource
+    SourceDescription
 } from 'theoplayer';
-import { getFirstYospaceTypedSource, yoSpaceWebSdkIsAvailable } from '../utils/YospaceUtils';
+import { getFirstYospaceTypedSource, type YospaceTypedSource, yoSpaceWebSdkIsAvailable } from '../utils/YospaceUtils';
 import { PlayerEvent } from '../yospace/PlayerEvent';
 import {
     PlaybackMode,


### PR DESCRIPTION
* We were importing `YospaceTypedSource` from THEOplayer rather than using our own definition. Fortunately, this was only used internally, so no users are impacted.
* We now require THEOplayer 8.1.0 or higher to avoid an issue with the TypeScript type definitions in THEOplayer 8.0.0. [See changelog.](https://www.theoplayer.com/docs/theoplayer/changelog/#-810-20240924)