### PR TITLE
Disable connector for HESP requests

### DIFF
--- a/.changeset/sixty-knives-do.md
+++ b/.changeset/sixty-knives-do.md
@@ -1,0 +1,5 @@
+---
+"@theoplayer/cmcd-connector-web": minor
+---
+
+Disable CMCD for HESP requests

--- a/cmcd/src/CMCDCollector.ts
+++ b/cmcd/src/CMCDCollector.ts
@@ -59,7 +59,7 @@ export class CMCDCollector {
      */
     private handleCurrentSourceChange_ = (event: CurrentSourceChangeEvent) => {
         const currentSource = event.currentSource;
-        if (!currentSource) {
+        if (!currentSource || currentSource.type === 'application/vnd.theo.hesp+json') {
             this._streamingFormat = undefined;
         } else {
             this._streamingFormat = getStreamingFormatFromTypedSource(currentSource);
@@ -138,9 +138,13 @@ export class CMCDCollector {
     /**
      * Collects all the CMCD parameters as supported by the connector depending on the provided {@link Request}.
      * @param request The request for which CMCD parameters should be collected.
-     * @returns A payload object containing keys for the provided request.
+     * @returns A payload object containing keys for the provided request or `undefined` if CMCD is not applicable for
+     * this request
      */
-    collect(request: Request): CMCDPayload {
+    collect(request: Request): CMCDPayload | undefined {
+        if (this._streamingFormat === undefined) {
+            return;
+        }
         const sessionKeys = this.collectSessionKeys();
         const requestKeys = this._config.sendRequestID
             ? {

--- a/cmcd/src/CMCDConnector.ts
+++ b/cmcd/src/CMCDConnector.ts
@@ -62,6 +62,9 @@ export class CMCDConnector {
         }
 
         let payload = this._collector.collect(request);
+        if (payload === undefined) {
+            return;
+        }
         if (this._processor) {
             payload = this._processor(payload, request);
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "prettier": "^3.2.4",
         "rimraf": "^5.0.5",
         "rollup": "^4.14.0",
-        "theoplayer": "^7.12.0",
+        "theoplayer": "^8.3.0",
         "ts-jest": "^29.1.2",
         "ts-node": "^10.9.2",
         "tslib": "^2.6.2",
@@ -46,7 +46,7 @@
     },
     "adscript": {
       "name": "@theoplayer/adscript-connector-web",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "peerDependencies": {
         "theoplayer": "^7.0.0 || ^8.0.0"
@@ -54,7 +54,7 @@
     },
     "cmcd": {
       "name": "@theoplayer/cmcd-connector-web",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "license": "MIT",
       "peerDependencies": {
         "theoplayer": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -62,7 +62,7 @@
     },
     "comscore": {
       "name": "@theoplayer/comscore-connector-web",
-      "version": "1.0.21",
+      "version": "1.2.0",
       "license": "MIT",
       "peerDependencies": {
         "theoplayer": "^7.0.0 || ^8.0.0"
@@ -70,7 +70,7 @@
     },
     "conviva": {
       "name": "@theoplayer/conviva-connector-web",
-      "version": "2.1.4",
+      "version": "2.3.0",
       "license": "MIT",
       "devDependencies": {
         "@convivainc/conviva-js-coresdk": "^4.7.4"
@@ -88,7 +88,7 @@
     },
     "gemius": {
       "name": "@theoplayer/gemius-connector-web",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "peerDependencies": {
         "theoplayer": "^7.0.0 || ^8.0.0"
@@ -96,7 +96,7 @@
     },
     "nielsen": {
       "name": "@theoplayer/nielsen-connector-web",
-      "version": "1.2.0",
+      "version": "1.4.0",
       "license": "MIT",
       "peerDependencies": {
         "theoplayer": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -7880,9 +7880,10 @@
       "license": "MIT"
     },
     "node_modules/theoplayer": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/theoplayer/-/theoplayer-7.12.0.tgz",
-      "integrity": "sha512-Vikb20iermLQz0IZRnzwzuvzGTbpxxmIYXHJPuiwRGfP8EtaS43+94GPlxgMGYrFlvwXIa7zi1qFF+M/mCvTdQ=="
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/theoplayer/-/theoplayer-8.3.0.tgz",
+      "integrity": "sha512-KV9cpPQHVv8cvtt88lRCM+u+gXd64PlDmDq7Yqzcgkoy7RXisHqtiTdxnCO7U2zkMLNy4rM8WVnjWKZNrDbC0g==",
+      "license": "SEE LICENSE AT https://www.theoplayer.com/terms"
     },
     "node_modules/tmp": {
       "version": "0.0.33",
@@ -8763,7 +8764,7 @@
     },
     "yospace": {
       "name": "@theoplayer/yospace-connector-web",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "license": "MIT",
       "peerDependencies": {
         "theoplayer": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "prettier": "^3.2.4",
     "rimraf": "^5.0.5",
     "rollup": "^4.14.0",
-    "theoplayer": "^7.12.0",
+    "theoplayer": "^8.3.0",
     "ts-jest": "^29.1.2",
     "ts-node": "^10.9.2",
     "tslib": "^2.6.2",


### PR DESCRIPTION
This PR makes sure that CMCD headers for HESP requests are not added. 