### PR TITLE
Bugfix/conviva/ad content type

### DIFF
--- a/.changeset/spotty-snakes-explode.md
+++ b/.changeset/spotty-snakes-explode.md
@@ -1,0 +1,5 @@
+---
+"@theoplayer/conviva-connector-web": patch
+---
+
+Fixed an issue where the content type of an ad would sometimes be reported as "Live".

--- a/conviva/src/utils/Utils.ts
+++ b/conviva/src/utils/Utils.ts
@@ -226,6 +226,9 @@ export function collectAdMetadata(ad: Ad): ConvivaMetadata {
     // The name of the Ad Stitcher. If not using an Ad Stitcher, set to "NA"
     adMetadata['c3.ad.adStitcher'] = 'NA';
 
+    // Report ad content type
+    adMetadata[Constants.IS_LIVE] = Constants.StreamType.VOD;
+
     return adMetadata;
 }
 


### PR DESCRIPTION
Ads should not be reported with content type live.

When checking the ads section in Conviva's Pulse dashboard, the Content Category should never be "Live".