### PR TITLE
Feature/conviva device metadata

### DIFF
--- a/.changeset/rare-readers-talk.md
+++ b/.changeset/rare-readers-talk.md
@@ -1,0 +1,5 @@
+---
+"@theoplayer/conviva-connector-web": patch
+---
+
+Fixed an issue where an asset name, provided via a `ConvivaMetadata` object in the `ConvivaConnector` initialization, stops getting reported after a `sourcechange` event.

--- a/.changeset/sixty-pots-teach.md
+++ b/.changeset/sixty-pots-teach.md
@@ -1,0 +1,5 @@
+---
+"@theoplayer/conviva-connector-web": minor
+---
+
+Added `deviceMetadata` property to `ConvivaConfiguration`.

--- a/conviva/README.md
+++ b/conviva/README.md
@@ -43,7 +43,7 @@ First you need to define the Conviva metadata and configuration:
     };
 ```
 
-Optionally, you can include device metadata in the ConvivaConfiguration object
+Optionally, you can include device metadata in the ConvivaConfiguration object. Note that `SCREEN_RESOLUTION_WIDTH`, `SCREEN_RESOLUTION_HEIGHT` and `SCREEN_RESOLUTION_SCALE_FACTOR` are the only fields that Conviva will auto-collect on most web-based platforms.
 
 ```typescript
 const exampleDeviceMetadata: ConvivaDeviceMetadata = {

--- a/conviva/README.md
+++ b/conviva/README.md
@@ -93,6 +93,11 @@ The Conviva connector is now ready to start a session once THEOplayer starts pla
 
 Note that the `convivaMetadata` provided to the `ConvivaConnector` constructor is primarily used to pass on to the Conviva SDK's `reportPlaybackRequested`. If a source is set to the player after initialisation the connector, you should always provide the corresponding metadata (again) through the connector's `setContentInfo` method.
 
+```js
+player.source = exampleSource;
+convivaIntegration.setContentInfo(exampleSourceMetadata);
+```
+
 ## Usage with Yospace connector
 
 If you have a Yospace SSAI stream and want to also report ad related events to Conviva, you can use this connector in combination with the Yospace connector: [@theoplayer/yospace-connector-web](https://www.npmjs.com/package/@theoplayer/yospace-connector-web)

--- a/conviva/README.md
+++ b/conviva/README.md
@@ -91,7 +91,7 @@ Using these configs you can create the Conviva connector with THEOplayer.
 
 The Conviva connector is now ready to start a session once THEOplayer starts playing a source.
 
-Note that the `convivaMetadata` provided to the `ConvivaConnector` constructor is primarily used to pass on to the Conviva SDK's `reportPlaybackRequested`. If a source is set to the player after initialisation the connector, you should always provide the corresponding metadata (again) through the connector's `setContentInfo` method.
+Note that the `convivaMetadata` provided to the `ConvivaConnector` constructor is primarily used to pass on to the Conviva SDK's `reportPlaybackRequested`. If a source is set to the player after initializing the connector, you should always provide the corresponding metadata (again) through the connector's `setContentInfo` method.
 
 ```js
 player.source = exampleSource;

--- a/conviva/README.md
+++ b/conviva/README.md
@@ -43,6 +43,26 @@ First you need to define the Conviva metadata and configuration:
     };
 ```
 
+Optionally, you can include device metadata in the ConvivaConfiguration object
+
+```typescript
+const exampleDeviceMetadata: ConvivaDeviceMetadata = {
+    [Constants.DeviceMetadata.BRAND]: "Samsung",
+    [Constants.DeviceMetadata.MANUFACTURER]: "Samsung",
+    [Constants.DeviceMetadata.MODEL]: "QE43Q64BAUXXN",
+    [Constants.DeviceMetadata.TYPE]:  Constants.DeviceType.SMARTTV,
+    [Constants.DeviceMetadata.VERSION]: "6.5.0",
+    [Constants.DeviceMetadata.OS_NAME]: "Tizen",
+    [Constants.DeviceMetadata.OS_VERSION]: "6.5.0",
+    [Constants.DeviceMetadata.CATEGORY]: Constants.DeviceCategory.SAMSUNG_TV,
+    [Constants.DeviceMetadata.SCREEN_RESOLUTION_WIDTH]: 3840,
+    [Constants.DeviceMetadata.SCREEN_RESOLUTION_HEIGHT]: 2160,
+    [Constants.DeviceMetadata.SCREEN_RESOLUTION_SCALE_FACTOR]: 1
+}
+
+convivaMetadata.deviceMetadata = exampleDeviceMetadata
+```
+
 Using these configs you can create the Conviva connector with THEOplayer.
 
 * Add as a regular script:

--- a/conviva/README.md
+++ b/conviva/README.md
@@ -91,6 +91,8 @@ Using these configs you can create the Conviva connector with THEOplayer.
 
 The Conviva connector is now ready to start a session once THEOplayer starts playing a source.
 
+Note that the `convivaMetadata` provided to the `ConvivaConnector` constructor is primarily used to pass on to the Conviva SDK's `reportPlaybackRequested`. If a source is set to the player after initialisation the connector, you should always provide the corresponding metadata (again) through the connector's `setContentInfo` method.
+
 ## Usage with Yospace connector
 
 If you have a Yospace SSAI stream and want to also report ad related events to Conviva, you can use this connector in combination with the Yospace connector: [@theoplayer/yospace-connector-web](https://www.npmjs.com/package/@theoplayer/yospace-connector-web)

--- a/conviva/package.json
+++ b/conviva/package.json
@@ -21,7 +21,7 @@
     "bundle": "rollup -c rollup.config.mjs",
     "watch": "npm run bundle -- --watch",
     "build": "npm run clean && npm run bundle",
-    "serve": "http-server ./.. -o /conviva/test/pages/main_umd.html",
+    "serve": "http-server ./.. -o /conviva/test/pages/",
     "test": "jest"
   },
   "author": "THEO Technologies NV",

--- a/conviva/package.json
+++ b/conviva/package.json
@@ -21,7 +21,7 @@
     "bundle": "rollup -c rollup.config.mjs",
     "watch": "npm run bundle -- --watch",
     "build": "npm run clean && npm run bundle",
-    "serve": "http-server",
+    "serve": "http-server ./.. -o /conviva/test/pages/main_umd.html",
     "test": "jest"
   },
   "author": "THEO Technologies NV",

--- a/conviva/src/integration/ConvivaConnector.ts
+++ b/conviva/src/integration/ConvivaConnector.ts
@@ -20,7 +20,8 @@ export class ConvivaConnector {
     }
 
     /**
-     * Sets Conviva metadata on the Conviva video analytics.
+     * Sets Conviva metadata on the Conviva video analytics. Use this method to set source 
+     * specific metadata after setting a source to the player.
      * @param metadata object of key value pairs
      */
     setContentInfo(metadata: ConvivaMetadata): void {

--- a/conviva/src/integration/ConvivaHandler.ts
+++ b/conviva/src/integration/ConvivaHandler.ts
@@ -329,7 +329,9 @@ export class ConvivaHandler {
     private readonly onSourceChange = () => {
         this.maybeReportPlaybackEnded();
         this.currentSource = this.player.source;
-        this.customMetadata = {};
+        if (this.currentSource === undefined) {
+            this.customMetadata = {}
+        } 
     };
 
     private readonly onEnded = () => {

--- a/conviva/src/integration/ConvivaHandler.ts
+++ b/conviva/src/integration/ConvivaHandler.ts
@@ -4,7 +4,8 @@ import {
     Analytics,
     Constants,
     type ConvivaMetadata,
-    type VideoAnalytics
+    type VideoAnalytics,
+    ConvivaDeviceMetadata,
 } from '@convivainc/conviva-js-coresdk';
 import type { YospaceConnector } from '@theoplayer/yospace-connector-web';
 import { CONVIVA_CALLBACK_FUNCTIONS } from './ConvivaCallbackFunctions';
@@ -12,7 +13,7 @@ import {
     calculateBufferLength,
     calculateConvivaOptions,
     collectContentMetadata,
-    collectDeviceMetadata,
+    collectDefaultDeviceMetadata,
     collectPlayerInfo,
     flattenErrorObject
 } from '../utils/Utils';
@@ -25,6 +26,7 @@ export interface ConvivaConfiguration {
     customerKey: string;
     debug?: boolean;
     gatewayUrl?: string;
+    deviceMetadata?: ConvivaDeviceMetadata;
 }
 
 export class ConvivaHandler {
@@ -52,7 +54,7 @@ export class ConvivaHandler {
         this.convivaConfig = config;
         this.currentSource = player.source;
 
-        Analytics.setDeviceMetadata(collectDeviceMetadata());
+        Analytics.setDeviceMetadata(this.convivaConfig.deviceMetadata ?? collectDefaultDeviceMetadata());
         Analytics.init(
             this.convivaConfig.customerKey,
             CONVIVA_CALLBACK_FUNCTIONS,

--- a/conviva/src/integration/ConvivaHandler.ts
+++ b/conviva/src/integration/ConvivaHandler.ts
@@ -5,7 +5,7 @@ import {
     Constants,
     type ConvivaMetadata,
     type VideoAnalytics,
-    ConvivaDeviceMetadata,
+    ConvivaDeviceMetadata
 } from '@convivainc/conviva-js-coresdk';
 import type { YospaceConnector } from '@theoplayer/yospace-connector-web';
 import { CONVIVA_CALLBACK_FUNCTIONS } from './ConvivaCallbackFunctions';
@@ -244,7 +244,11 @@ export class ConvivaHandler {
     private reportMetadata() {
         const src = this.player.src ?? '';
         const streamType = this.player.duration === Infinity ? Constants.StreamType.LIVE : Constants.StreamType.VOD;
-        const assetName = this.customMetadata[Constants.ASSET_NAME] ?? this.convivaMetadata[Constants.ASSET_NAME] ?? this.currentSource?.metadata?.title ?? 'NA';
+        const assetName =
+            this.customMetadata[Constants.ASSET_NAME] ??
+            this.convivaMetadata[Constants.ASSET_NAME] ??
+            this.currentSource?.metadata?.title ??
+            'NA';
         const playerName = this.customMetadata[Constants.PLAYER_NAME] ?? 'THEOplayer';
         const metadata = {
             [Constants.STREAM_URL]: src,
@@ -328,7 +332,7 @@ export class ConvivaHandler {
     private readonly onSourceChange = () => {
         this.maybeReportPlaybackEnded();
         this.currentSource = this.player.source;
-        this.customMetadata = {}
+        this.customMetadata = {};
     };
 
     private readonly onEnded = () => {

--- a/conviva/src/integration/ConvivaHandler.ts
+++ b/conviva/src/integration/ConvivaHandler.ts
@@ -329,9 +329,7 @@ export class ConvivaHandler {
     private readonly onSourceChange = () => {
         this.maybeReportPlaybackEnded();
         this.currentSource = this.player.source;
-        if (this.currentSource === undefined) {
-            this.customMetadata = {}
-        } 
+        this.customMetadata = {}
     };
 
     private readonly onEnded = () => {

--- a/conviva/src/integration/ConvivaHandler.ts
+++ b/conviva/src/integration/ConvivaHandler.ts
@@ -245,7 +245,7 @@ export class ConvivaHandler {
     private reportMetadata() {
         const src = this.player.src ?? '';
         const streamType = this.player.duration === Infinity ? Constants.StreamType.LIVE : Constants.StreamType.VOD;
-        const assetName = this.customMetadata[Constants.ASSET_NAME] ?? this.currentSource?.metadata?.title ?? 'NA';
+        const assetName = this.customMetadata[Constants.ASSET_NAME] ?? this.convivaMetadata[Constants.ASSET_NAME] ?? this.currentSource?.metadata?.title ?? 'NA';
         const playerName = this.customMetadata[Constants.PLAYER_NAME] ?? 'THEOplayer';
         const metadata = {
             [Constants.STREAM_URL]: src,

--- a/conviva/src/integration/ConvivaHandler.ts
+++ b/conviva/src/integration/ConvivaHandler.ts
@@ -50,7 +50,6 @@ export class ConvivaHandler {
     constructor(player: ChromelessPlayer, convivaMetaData: ConvivaMetadata, config: ConvivaConfiguration) {
         this.player = player;
         this.convivaMetadata = convivaMetaData;
-        this.customMetadata = convivaMetaData;
         this.convivaConfig = config;
         this.currentSource = player.source;
 

--- a/conviva/src/utils/Utils.ts
+++ b/conviva/src/utils/Utils.ts
@@ -21,7 +21,7 @@ import {
 } from 'theoplayer';
 import { ConvivaConfiguration } from '../integration/ConvivaHandler';
 
-export function collectDeviceMetadata(): ConvivaDeviceMetadata {
+export function collectDefaultDeviceMetadata(): ConvivaDeviceMetadata {
     // Most device metadata is auto-collected by Conviva.
     return {
         [Constants.DeviceMetadata.CATEGORY]: Constants.DeviceCategory.WEB

--- a/conviva/test/pages/main_esm.html
+++ b/conviva/test/pages/main_esm.html
@@ -4,16 +4,23 @@
     <meta charset="UTF-8"/>
     <title>Connector test page</title>
     <link rel="stylesheet" type="text/css" href="./../../../node_modules/theoplayer/ui.css"/>
-    <script src="./../../../node_modules/theoplayer/THEOplayer.js"></script>
-    <script src="./../../../node_modules/@convivainc/conviva-js-coresdk/conviva-core-sdk.js"></script>
-    <script src="./../../dist/conviva-connector.umd.js"></script>
 </head>
 <body>
 <div id="THEOplayer" class="theoplayer-container video-js theoplayer-skin"></div>
+<script type="importmap">
+    {
+      "imports": {
+        "theoplayer": "./../../../node_modules/theoplayer/THEOplayer.esm.js",
+        "@convivainc/conviva-js-coresdk": "https://esm.sh/@convivainc/conviva-js-coresdk@4.7.12?exports=Constants,Analytics"
+      }
+    }
+</script>
 <script type="module">
-    import { ConvivaConnector } from "/dist/conviva-connector.esm.js";
+    import { Player } from "theoplayer"
+    import { ConvivaConnector } from "./../../dist/conviva-connector.esm.js";
+    import * as Conviva from "@convivainc/conviva-js-coresdk";
     const element = document.querySelector('#THEOplayer');
-    const player = new THEOplayer.Player(element, {
+    const player = new Player(element, {
         ui: {
             fluid: true
         },

--- a/conviva/test/pages/main_umd.html
+++ b/conviva/test/pages/main_umd.html
@@ -31,7 +31,20 @@
     const convivaConfig = {
         debug: false,
         gatewayUrl: 'CUSTOMER_GATEWAY_GOES_HERE',
-        customerKey: 'CUSTOMER_KEY_GOES_HERE' // Can be a test or production key.
+        customerKey: 'CUSTOMER_KEY_GOES_HERE', // Can be a test or production key.
+        deviceMetadata: {
+            [Conviva.Constants.DeviceMetadata.BRAND]: "Chrome",
+            [Conviva.Constants.DeviceMetadata.MANUFACTURER]: "Apple",
+            [Conviva.Constants.DeviceMetadata.MODEL]: "MacBook Pro M2",
+            [Conviva.Constants.DeviceMetadata.TYPE]:  Conviva.Client.DeviceType.DESKTOP,
+            [Conviva.Constants.DeviceMetadata.VERSION]: "131.0.6778.86",
+            [Conviva.Constants.DeviceMetadata.OS_NAME]: "macOS Sonoma",
+            [Conviva.Constants.DeviceMetadata.OS_VERSION]: "14.7.0",
+            [Conviva.Constants.DeviceMetadata.CATEGORY]: Conviva.Client.DeviceCategory.APPLE_DEVICE,
+            [Conviva.Constants.DeviceMetadata.SCREEN_RESOLUTION_WIDTH]: 3024,
+            [Conviva.Constants.DeviceMetadata.SCREEN_RESOLUTION_HEIGHT]: 1964,
+            [Conviva.Constants.DeviceMetadata.SCREEN_RESOLUTION_SCALE_FACTOR]: 1
+        }
     };
 
     const convivaIntegration = new THEOplayerConvivaConnector.ConvivaConnector(

--- a/conviva/test/pages/main_umd.html
+++ b/conviva/test/pages/main_umd.html
@@ -31,20 +31,7 @@
     const convivaConfig = {
         debug: false,
         gatewayUrl: 'CUSTOMER_GATEWAY_GOES_HERE',
-        customerKey: 'CUSTOMER_KEY_GOES_HERE', // Can be a test or production key.
-        deviceMetadata: {
-            [Conviva.Constants.DeviceMetadata.BRAND]: "Chrome",
-            [Conviva.Constants.DeviceMetadata.MANUFACTURER]: "Apple",
-            [Conviva.Constants.DeviceMetadata.MODEL]: "MacBook Pro M2",
-            [Conviva.Constants.DeviceMetadata.TYPE]:  Conviva.Client.DeviceType.DESKTOP,
-            [Conviva.Constants.DeviceMetadata.VERSION]: "131.0.6778.86",
-            [Conviva.Constants.DeviceMetadata.OS_NAME]: "macOS Sonoma",
-            [Conviva.Constants.DeviceMetadata.OS_VERSION]: "14.7.0",
-            [Conviva.Constants.DeviceMetadata.CATEGORY]: Conviva.Client.DeviceCategory.APPLE_DEVICE,
-            [Conviva.Constants.DeviceMetadata.SCREEN_RESOLUTION_WIDTH]: 3024,
-            [Conviva.Constants.DeviceMetadata.SCREEN_RESOLUTION_HEIGHT]: 1964,
-            [Conviva.Constants.DeviceMetadata.SCREEN_RESOLUTION_SCALE_FACTOR]: 1
-        }
+        customerKey: 'CUSTOMER_KEY_GOES_HERE' // Can be a test or production key. 
     };
 
     const convivaIntegration = new THEOplayerConvivaConnector.ConvivaConnector(


### PR DESCRIPTION
This PR adds an optional property `deviceMetadata` to the [ConvivaConfiguration](https://theoplayer.github.io/web-connectors/api/interfaces/Conviva_Connector.ConvivaConfiguration.html). This allows users to pass the desired device metadata to the Conviva SDK.

It also includes a fix for an issue where te asset name was reported as `"NA"` after a few seconds. This could happen for users that just pass the content metadata only through the `ConvivaConnector` constructor and set the player source right after that.