### PR TITLE
Do no include streamType on NaN duration

### DIFF
--- a/.changeset/khaki-planes-end.md
+++ b/.changeset/khaki-planes-end.md
@@ -1,0 +1,5 @@
+---
+"@theoplayer/conviva-connector-web": patch
+---
+
+Fixed an issue where the stream type, either `VOD` or `Live`, would sometimes be set with a wrong value for live streams.

--- a/conviva/src/integration/ConvivaHandler.ts
+++ b/conviva/src/integration/ConvivaHandler.ts
@@ -243,18 +243,19 @@ export class ConvivaHandler {
 
     private reportMetadata() {
         const src = this.player.src ?? '';
-        const streamType = this.player.duration === Infinity ? Constants.StreamType.LIVE : Constants.StreamType.VOD;
         const assetName =
             this.customMetadata[Constants.ASSET_NAME] ??
             this.convivaMetadata[Constants.ASSET_NAME] ??
             this.currentSource?.metadata?.title ??
             'NA';
         const playerName = this.customMetadata[Constants.PLAYER_NAME] ?? 'THEOplayer';
-        const metadata = {
+        const hasDuration = !Number.isNaN(this.player.duration);
+        const isLive = Number.isFinite(this.player.duration) ? Constants.StreamType.VOD : Constants.StreamType.LIVE;
+        const metadata: ConvivaMetadata = {
             [Constants.STREAM_URL]: src,
-            [Constants.IS_LIVE]: streamType,
             [Constants.ASSET_NAME]: assetName,
-            [Constants.PLAYER_NAME]: playerName
+            [Constants.PLAYER_NAME]: playerName,
+            ...(!hasDuration ? {} : { [Constants.IS_LIVE]: isLive })
         };
         this.setContentInfo(metadata);
     }


### PR DESCRIPTION
Fixed an issue where VOD/Live streamType was set with a wrong value.

Because metadata is set early, and streamType was included, the asset almost always still had duration == 'NaN', which resulted in a VOD streamType.
We should not set a streamType until the duration is known, or if the connector user sets it through editorial data, like so:

```
    convivaIntegration.setContentInfo({
        'Conviva.streamType': 'LIVE'
    });
```