### PR TITLE
Maintenance/pass server guided

### DIFF
--- a/.changeset/warm-bags-beg.md
+++ b/.changeset/warm-bags-beg.md
@@ -1,0 +1,5 @@
+---
+"@theoplayer/conviva-connector-web": patch
+---
+
+Added 'Server Guided' as ad type passed when reporting a THEOads ad break has started.

--- a/conviva/src/utils/Utils.ts
+++ b/conviva/src/utils/Utils.ts
@@ -28,15 +28,10 @@ export function collectDefaultDeviceMetadata(): ConvivaDeviceMetadata {
     };
 }
 
-export function isServerGuidedAd(adOrBreak: Ad | AdBreak) {
-    return adOrBreak.integration === 'theoads';
-}
-
 export function calculateAdType(adOrBreak: Ad | AdBreak) {
     switch (adOrBreak.integration) {
         case 'theoads': {
-            // TODO: THEOads is a Server-Guided Ad Insertion (SGAI) solution, which can't be reported to Conviva as such yet.
-            return Constants.AdType.SERVER_SIDE;
+            return 'Server Guided';
         }
         case undefined:
         case '':


### PR DESCRIPTION
Explicitly pass 'Server Guided' to `reportAdBreakStarted`. This contradicts with conviva their typings but they let us know on their end they handle it as any string so could already update it.