### PR TITLE
Retrieve playername from convivaMetadata if available

### DIFF
--- a/conviva/src/integration/ConvivaHandler.ts
+++ b/conviva/src/integration/ConvivaHandler.ts
@@ -251,7 +251,10 @@ export class ConvivaHandler {
             this.convivaMetadata[Constants.ASSET_NAME] ??
             this.currentSource?.metadata?.title ??
             'NA';
-        const playerName = this.customMetadata[Constants.PLAYER_NAME] ?? 'THEOplayer';
+        const playerName =
+            this.customMetadata[Constants.PLAYER_NAME] ??
+            this.convivaMetadata[Constants.PLAYER_NAME] ??
+            'THEOplayer';
         const hasDuration = !Number.isNaN(this.player.duration);
         const isLive = Number.isFinite(this.player.duration) ? Constants.StreamType.VOD : Constants.StreamType.LIVE;
         const metadata: ConvivaMetadata = {


### PR DESCRIPTION
This pull request adds the capability to retrieve the PLAYER_NAME (mapped to 'Conviva.applicationName') from the convivaMetadata object. This allow to set the value once on initialisation of the ConvivaHandler.

Example:

```
const configuration = {}

const metadata = {
 [Constants.PLAYER_NAME]: 'MY_PLAYER'
}

const connector = new ConvivaConnector(
  player, // theoplayer reference
  metadata, // metadata object
  configuration,
)
```