### PR TITLE
Feature/conviva/split stack

### DIFF
--- a/.changeset/brown-mangos-learn.md
+++ b/.changeset/brown-mangos-learn.md
@@ -1,0 +1,5 @@
+---
+"@theoplayer/conviva-connector-web": minor
+---
+
+Added full call stack info to an error report by splitting it in multiple entries.


### PR DESCRIPTION
In case of an error, we currently get only the first part of a call stack because Conviva truncates the values at 256 chars. 
By splitting the call stack in multiple entries, we get all info.