### PR TITLE
Minor changes to Gemius analytics

### DIFF
--- a/gemius/CHANGELOG.md
+++ b/gemius/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @theoplayer/gemius-connector-web
 
+## 0.3.1
+
+### ✨ Issues
+
+- removed newProgram for every ad to content transition
+- removed close event for every ad end
+
 ## 0.3.0
 
 ### ✨ Features

--- a/gemius/package.json
+++ b/gemius/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@theoplayer/gemius-connector-web",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "A connector implementing Gemius with THEOplayer",
   "main": "dist/gemius-connector.umd.js",
   "module": "dist/gemius-connector.esm.js",

--- a/gemius/src/integration/GemiusTHEOIntegration.ts
+++ b/gemius/src/integration/GemiusTHEOIntegration.ts
@@ -252,8 +252,6 @@ export class GemiusTHEOIntegration {
         const { adBreak } = event;
         const { timeOffset } = adBreak;
         if (!this.isPreRoll(adBreak)) this.partCount++;
-        const { programID, customAttributes, ...additionalParameters } = this.programParameters;
-        this.gemiusPlayer.newProgram(programID, { ...additionalParameters, ...customAttributes });
         this.player.removeEventListener('playing', this.onFirstPlaying);
         if (timeOffset === 0) this.player.addEventListener('playing', this.onFirstPlaying);
     };
@@ -284,7 +282,6 @@ export class GemiusTHEOIntegration {
         const { timeOffset } = adBreak;
         const normalizedTimeOffset = this.normalizeTime(timeOffset);
         this.gemiusPlayer.adEvent(programID, ad.id ?? DEFAULT_AD_ID, normalizedTimeOffset, BasicEvent.COMPLETE);
-        this.gemiusPlayer.adEvent(programID, ad.id ?? DEFAULT_AD_ID, normalizedTimeOffset, BasicEvent.CLOSE);
         this.adCount++;
         this.currentAd = undefined;
         this.player.removeEventListener('playing', this.onFirstPlaying);


### PR DESCRIPTION
Based on the feedback we received directly from gemius during testing/production there are two events that were sent unnecessarily in the original connector.

- newProgram should be sent only once at the beginning of the "source", before ads
- close event should be sent only when the browser/window is closed (although there is a minor inconsistency with the doc version)

![eventOverview](https://github.com/user-attachments/assets/c0ad3447-e3de-4c53-b6ce-46e24f6dea0e)
