### PR TITLE
Adscript changes and fixes

### DIFF
--- a/.changeset/curvy-deers-kiss.md
+++ b/.changeset/curvy-deers-kiss.md
@@ -1,0 +1,5 @@
+---
+"@theoplayer/adscript-connector-web": minor
+---
+
+Fixed attribute value for ad metadata

--- a/.changeset/fluffy-files-clap.md
+++ b/.changeset/fluffy-files-clap.md
@@ -1,0 +1,5 @@
+---
+"@theoplayer/adscript-connector-web": minor
+---
+
+Added player state visibility flooring for decimal numbers

--- a/.changeset/khaki-chairs-work.md
+++ b/.changeset/khaki-chairs-work.md
@@ -1,0 +1,5 @@
+---
+"@theoplayer/adscript-connector-web": minor
+---
+
+Fixed adscript quartile events naming

--- a/.changeset/rare-rabbits-travel.md
+++ b/.changeset/rare-rabbits-travel.md
@@ -1,0 +1,5 @@
+---
+"@theoplayer/adscript-connector-web": minor
+---
+
+Added adscript buffer/multiple player support

--- a/.changeset/seven-ties-press.md
+++ b/.changeset/seven-ties-press.md
@@ -1,0 +1,5 @@
+---
+"@theoplayer/adscript-connector-web": minor
+---
+
+Added ASMEA code loading from the vast akaCode param

--- a/.changeset/shy-apes-boil.md
+++ b/.changeset/shy-apes-boil.md
@@ -1,0 +1,5 @@
+---
+"@theoplayer/adscript-connector-web": minor
+---
+
+Fixed ad/content `attributes` property to `attribute`

--- a/.changeset/sixty-lemons-own.md
+++ b/.changeset/sixty-lemons-own.md
@@ -1,0 +1,5 @@
+---
+"@theoplayer/adscript-connector-web": minor
+---
+
+JHMT load script null reference fixes

--- a/.changeset/thin-years-pull.md
+++ b/.changeset/thin-years-pull.md
@@ -1,0 +1,5 @@
+---
+"@theoplayer/adscript-connector-web": minor
+---
+
+Moved ad start to playing from adbegin

--- a/adscript/src/adscript/AdScript.d.ts
+++ b/adscript/src/adscript/AdScript.d.ts
@@ -22,6 +22,11 @@ interface StaticContentMetadata {
     ref: string;
 }
 
+interface BufferMetadata {
+    contentMetadata?: MainVideoContentMetadata;
+    playerState?: PlayerState;
+}
+
 export interface PlayerState {
     muted: number;
     volume: number;
@@ -54,4 +59,8 @@ export interface JHMTApi {
     setContentMetadata(contentMetadata: ContentMetadata);
 
     setPlayerState(playerState: PlayerState);
+
+    addBuffer(bufferName: string, playerId: string, bufferMetadata: BufferMetadata);
+
+    setBuffer(bufferName: string, bufferMetadata: BufferMetadata);
 }

--- a/adscript/src/integration/AdScriptConfiguration.ts
+++ b/adscript/src/integration/AdScriptConfiguration.ts
@@ -13,7 +13,7 @@ export interface MainVideoContentMetadata {
     crossId: string;
     livestream: string;
     channelId: string;
-    attributes: string;
+    attribute: string;
 }
 
 /**
@@ -25,7 +25,7 @@ export interface EmbeddedContentMetadata {
     length: string;
     title: string;
     asmea: string;
-    attributes: string;
+    attribute: string;
 }
 
 /**

--- a/adscript/src/integration/AdScriptConnector.ts
+++ b/adscript/src/integration/AdScriptConnector.ts
@@ -44,11 +44,10 @@ export class AdScriptConnector {
             return;
         }
         if (typeof window.JHMTApi === 'object') {
-            this.adScriptIntegration = new AdScriptTHEOIntegration(this.player, this.configuration);
+            this.adScriptIntegration = new AdScriptTHEOIntegration(this.player, this.configuration, this.metadata);
             if (this.i12n) {
                 this.adScriptIntegration.updateUser(this.i12n);
             }
-            this.adScriptIntegration.updateMetadata(this.metadata);
             this.adScriptIntegration.start();
             return;
         }

--- a/adscript/src/integration/LoadAdScriptSDK.ts
+++ b/adscript/src/integration/LoadAdScriptSDK.ts
@@ -31,7 +31,9 @@ function loadAdScriptInternal(j, h, m, t, c, z) {
               }),
         (b.src = j['JHMTApiProtocol'] + '//cm' + i + '.jhmt.cz/api.js'),
         (b.onerror = function () {
-            b.parentNode.removeChild(b);
+            if (b.parentNode !== 'undefined') {
+                b.parentNode.removeChild(b);
+            }
             z++;
             i = (z % 3) + 1;
             loadAdScriptInternal(j, h, m, t, c, i);
@@ -43,7 +45,9 @@ function loadAdScriptInternal(j, h, m, t, c, z) {
             if (typeof j.JHMTApi !== 'undefined') {
                 clearInterval(it);
             } else {
-                b.parentNode.removeChild(b);
+                if (b.parentNode !== 'undefined') {
+                    b.parentNode.removeChild(b);
+                }
                 z++;
                 i = (z % 3) + 1;
                 loadAdScriptInternal(j, h, m, t, c, i);


### PR DESCRIPTION
Mainly support for buffers and multiple players with testing/production changes and fixes

JHMT buffer docs:
https://adscript.admosphere.cz/cz_adScript_browser.html#line2

- Fixed attribute value for ad metadata
- Added player state visibility flooring for decimal numbers
- Fixed adscript quartile events naming
- Added adscript buffer/multiple player support
- Added ASMEA code loading from the vast akaCode param
- Fixed ad/content `attributes` property to `attribute`
- JHMT load script null reference fixes
- Moved ad start to playing from adbegin