### PR TITLE
Feature/conviva/islive override

### DIFF
--- a/.changeset/eleven-parrots-draw.md
+++ b/.changeset/eleven-parrots-draw.md
@@ -1,0 +1,5 @@
+---
+"@theoplayer/conviva-connector-web": minor
+---
+
+Added play-out configuration values such as `liveOffset`, `targetBuffer`, `bufferLookbackWindow`, `abrStrategy` and `abrMetadata` as custom metadata fields.

--- a/.changeset/warm-moose-marry.md
+++ b/.changeset/warm-moose-marry.md
@@ -1,0 +1,5 @@
+---
+"@theoplayer/conviva-connector-web": minor
+---
+
+Fixed an issue where the `streamType` value set through the connector API could be overriden with a different value by the connector.

--- a/conviva/src/integration/ConvivaHandler.ts
+++ b/conviva/src/integration/ConvivaHandler.ts
@@ -14,6 +14,7 @@ import {
     calculateConvivaOptions,
     calculateStreamType,
     collectDefaultDeviceMetadata,
+    collectPlaybackConfigMetadata,
     collectPlayerInfo
 } from '../utils/Utils';
 import { AdReporter } from './ads/AdReporter';
@@ -254,7 +255,8 @@ export class ConvivaHandler {
         const metadata: ConvivaMetadata = {
             [Constants.STREAM_URL]: src,
             [Constants.ASSET_NAME]: assetName,
-            [Constants.PLAYER_NAME]: playerName
+            [Constants.PLAYER_NAME]: playerName,
+            ...collectPlaybackConfigMetadata(this.player)
         };
         // Only pass `isLive` property if we have a valid duration
         const streamType = calculateStreamType(this.player);

--- a/conviva/src/integration/ConvivaHandler.ts
+++ b/conviva/src/integration/ConvivaHandler.ts
@@ -258,10 +258,14 @@ export class ConvivaHandler {
             [Constants.PLAYER_NAME]: playerName,
             ...collectPlaybackConfigMetadata(this.player)
         };
-        // Only pass `isLive` property if we have a valid duration
-        const streamType = calculateStreamType(this.player);
-        if (streamType) {
-            metadata[Constants.IS_LIVE] = streamType;
+        // Do not override the `isLive` value if already set by the consumer, as the value
+        // is read-only for a given session.
+        if (!this.customMetadata[Constants.IS_LIVE] && !this.convivaMetadata[Constants.IS_LIVE]) {
+            // Only pass `isLive` property if we have a valid duration
+            const streamType = calculateStreamType(this.player);
+            if (streamType) {
+                metadata[Constants.IS_LIVE] = streamType;
+            }
         }
         // Only pass a finite duration value, never NaN or Infinite.
         if (isFinite(this.player.duration)) {

--- a/conviva/src/utils/Utils.ts
+++ b/conviva/src/utils/Utils.ts
@@ -102,6 +102,12 @@ export function calculateConvivaOptions(config: ConvivaConfiguration): ConvivaOp
     return options;
 }
 
+export function calculateStreamType(player: ChromelessPlayer) {
+    if (!Number.isNaN(player.duration)) {
+        return isFinite(player.duration) ? Constants.StreamType.VOD : Constants.StreamType.LIVE;
+    }
+}
+
 export function collectPlayerInfo(): ConvivaPlayerInfo {
     return {
         [Constants.FRAMEWORK_NAME]: 'THEOplayer',

--- a/conviva/src/utils/Utils.ts
+++ b/conviva/src/utils/Utils.ts
@@ -15,10 +15,8 @@ import {
     type GoogleImaAd,
     type VerizonMediaAd,
     type VerizonMediaAdBreak,
-    type THEOplayerError,
-    ErrorCategory,
-    ErrorCode,
-    version
+    version,
+    TypedSource
 } from 'theoplayer';
 import { ConvivaConfiguration } from '../integration/ConvivaHandler';
 
@@ -114,20 +112,20 @@ export function collectPlayerInfo(): ConvivaPlayerInfo {
         [Constants.FRAMEWORK_VERSION]: version
     };
 }
-
-export function collectContentMetadata(
-    player: ChromelessPlayer,
-    configuredContentMetadata: ConvivaMetadata
-): ConvivaMetadata {
-    const contentInfo: ConvivaMetadata = {};
-    const duration = player.duration;
-    if (!Number.isNaN(duration) && duration !== Infinity) {
-        contentInfo[Constants.DURATION] = duration;
+export function collectPlaybackConfigMetadata(player: ChromelessPlayer) {
+    const metadata: { [key: string]: string } = {};
+    if (player.abr.targetBuffer) {
+        metadata['targetBuffer'] = player.abr.targetBuffer.toString();
     }
-    return {
-        ...configuredContentMetadata,
-        ...contentInfo
-    };
+    if (player.abr.bufferLookbackWindow) {
+        metadata['bufferLookbackWindow'] = player.abr.bufferLookbackWindow.toString();
+    }
+    const source = Array.isArray(player.source?.sources) ? player.source?.sources[0] : player.source?.sources;
+    const liveOffset = (source as TypedSource)?.liveOffset?.toString();
+    if (liveOffset) {
+        metadata['liveOffset'] = liveOffset;
+    }
+    return metadata;
 }
 
 export function collectYospaceAdMetadata(player: ChromelessPlayer, ad: AdVert): ConvivaMetadata {

--- a/conviva/src/utils/Utils.ts
+++ b/conviva/src/utils/Utils.ts
@@ -120,6 +120,13 @@ export function collectPlaybackConfigMetadata(player: ChromelessPlayer) {
     if (player.abr.bufferLookbackWindow) {
         metadata['bufferLookbackWindow'] = player.abr.bufferLookbackWindow.toString();
     }
+    const abrStrategy = player.abr.strategy;
+    if (abrStrategy) {
+        metadata['abrStrategy'] = typeof abrStrategy === 'string' ? abrStrategy : abrStrategy.type.toString();
+        if (typeof abrStrategy !== 'string' && abrStrategy.metadata?.bitrate) {
+            metadata['abrMetadata'] = abrStrategy.metadata.bitrate.toString();
+        }
+    }
     const source = Array.isArray(player.source?.sources) ? player.source?.sources[0] : player.source?.sources;
     const liveOffset = (source as TypedSource)?.liveOffset?.toString();
     if (liveOffset) {

--- a/conviva/test/pages/main_esm.html
+++ b/conviva/test/pages/main_esm.html
@@ -48,6 +48,10 @@
             ['Conviva.assetName']: `Main page ${(new Date()).toLocaleString()}`,
             ['customTag1']: "customValue1",
             ['customTag2']: "customValue2",
+
+            // Optionally pass the streamType, otherwise the player will derive,
+            // but only once it has the stream's metadata.
+            // ['Conviva.streamType']: 'VOD' // or 'LIVE'
         }
         convivaIntegration.setContentInfo(metadata);
     }

--- a/conviva/test/pages/main_umd.html
+++ b/conviva/test/pages/main_umd.html
@@ -45,6 +45,10 @@
             ['Conviva.assetName']: `Main page ${(new Date()).toLocaleString()}`,
             ['customTag1']: "customValue1",
             ['customTag2']: "customValue2",
+
+            // Optionally pass the streamType, otherwise the player will derive,
+            // but only once it has the stream's metadata.
+            // ['Conviva.streamType']: 'VOD' // or 'LIVE'
         }
         convivaIntegration.setContentInfo(metadata);
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
     },
     "adscript": {
       "name": "@theoplayer/adscript-connector-web",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "peerDependencies": {
         "theoplayer": "^7.0.0 || ^8.0.0 || ^9.0.0"
@@ -54,7 +54,7 @@
     },
     "cmcd": {
       "name": "@theoplayer/cmcd-connector-web",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "MIT",
       "peerDependencies": {
         "theoplayer": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0"
@@ -62,7 +62,7 @@
     },
     "comscore": {
       "name": "@theoplayer/comscore-connector-web",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "MIT",
       "peerDependencies": {
         "theoplayer": "^7.0.0 || ^8.0.0 || ^9.0.0"
@@ -70,7 +70,7 @@
     },
     "conviva": {
       "name": "@theoplayer/conviva-connector-web",
-      "version": "2.6.0",
+      "version": "2.8.0",
       "license": "MIT",
       "devDependencies": {
         "@convivainc/conviva-js-coresdk": "^4.7.4"
@@ -88,7 +88,7 @@
     },
     "gemius": {
       "name": "@theoplayer/gemius-connector-web",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "peerDependencies": {
         "theoplayer": "^7.0.0 || ^8.0.0 || ^9.0.0"
@@ -96,7 +96,7 @@
     },
     "nielsen": {
       "name": "@theoplayer/nielsen-connector-web",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "MIT",
       "peerDependencies": {
         "theoplayer": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0"
@@ -8764,7 +8764,7 @@
     },
     "yospace": {
       "name": "@theoplayer/yospace-connector-web",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "license": "MIT",
       "peerDependencies": {
         "theoplayer": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.1.0 || ^9.0.0"

--- a/tools/build.mjs
+++ b/tools/build.mjs
@@ -17,6 +17,7 @@ export function getSharedBuildConfiguration({ fileName, globalName, banner, exte
                     format: 'umd',
                     indent: false,
                     banner,
+                    sourcemap: true,
                     globals: { theoplayer: 'THEOplayer', ...(globals ?? {}) }
                 },
                 {
@@ -24,6 +25,7 @@ export function getSharedBuildConfiguration({ fileName, globalName, banner, exte
                     entryFileNames: '[name].esm.js',
                     format: 'esm',
                     indent: false,
+                    sourcemap: true,
                     banner
                 }
             ],


### PR DESCRIPTION
- Simplify/restructure metadata passing
- Don't override the Conviva.streamType tag if it was already set by the customer through the API: the value is read-only in the back-end and can cause issues if it is set again with a different value.
- Pass extra stream config values as custom metadata: `liveOffset`, `targetBuffer`, `bufferLookbackWindow`, `abrStrategy` and `abrMetadata`.
- Add sourceMaps to modules to facilitate debugging.