### PR TITLE
Maintenance/conviva/replace verizion integration

### DIFF
--- a/.changeset/fast-cooks-dream.md
+++ b/.changeset/fast-cooks-dream.md
@@ -1,0 +1,5 @@
+---
+"@theoplayer/conviva-connector-web": minor
+---
+
+Replaced VerizonMedia player extension with Uplynk.

--- a/conviva/package.json
+++ b/conviva/package.json
@@ -42,9 +42,9 @@
     "package.json"
   ],
   "peerDependencies": {
-    "@convivainc/conviva-js-coresdk": "^4.7.4",
-    "@theoplayer/yospace-connector-web": "^2.1.2",
-    "theoplayer": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0"
+    "@convivainc/conviva-js-coresdk": "^4.8.0",
+    "@theoplayer/yospace-connector-web": "^2.6.0",
+    "theoplayer": "^5 || ^6 || ^7 || ^8 || ^9"
   },
   "peerDependenciesMeta": {
     "@theoplayer/yospace-connector-web": {
@@ -52,6 +52,6 @@
     }
   },
   "devDependencies": {
-    "@convivainc/conviva-js-coresdk": "^4.7.4"
+    "@convivainc/conviva-js-coresdk": "^4.8.0"
   }
 }

--- a/conviva/src/integration/ConvivaHandler.ts
+++ b/conviva/src/integration/ConvivaHandler.ts
@@ -19,7 +19,7 @@ import {
 } from '../utils/Utils';
 import { AdReporter } from './ads/AdReporter';
 import { YospaceAdReporter } from './ads/YospaceAdReporter';
-import { VerizonAdReporter } from './ads/VerizonAdReporter';
+import { UplynkAdReporter } from './ads/UplynkAdReporter';
 import { ErrorEvent } from 'theoplayer';
 import { ErrorReportBuilder } from '../utils/ErrorReportBuilder';
 
@@ -41,7 +41,7 @@ export class ConvivaHandler {
 
     private adReporter: AdReporter | undefined;
     private yospaceAdReporter: YospaceAdReporter | undefined;
-    private verizonAdReporter: VerizonAdReporter | undefined;
+    private verizonAdReporter: UplynkAdReporter | undefined;
 
     private currentSource: SourceDescription | undefined;
     private playbackRequested: boolean = false;
@@ -81,8 +81,8 @@ export class ConvivaHandler {
             () => this.customMetadata
         );
 
-        if (this.player.verizonMedia !== undefined) {
-            this.verizonAdReporter = new VerizonAdReporter(
+        if (this.player.uplynk !== undefined) {
+            this.verizonAdReporter = new UplynkAdReporter(
                 this.player,
                 this.convivaVideoAnalytics,
                 this.convivaAdAnalytics

--- a/conviva/src/integration/ConvivaHandler.ts
+++ b/conviva/src/integration/ConvivaHandler.ts
@@ -41,7 +41,7 @@ export class ConvivaHandler {
 
     private adReporter: AdReporter | undefined;
     private yospaceAdReporter: YospaceAdReporter | undefined;
-    private verizonAdReporter: UplynkAdReporter | undefined;
+    private uplynkAdReporter: UplynkAdReporter | undefined;
 
     private currentSource: SourceDescription | undefined;
     private playbackRequested: boolean = false;
@@ -82,7 +82,7 @@ export class ConvivaHandler {
         );
 
         if (this.player.uplynk !== undefined) {
-            this.verizonAdReporter = new UplynkAdReporter(
+            this.uplynkAdReporter = new UplynkAdReporter(
                 this.player,
                 this.convivaVideoAnalytics,
                 this.convivaAdAnalytics
@@ -369,10 +369,10 @@ export class ConvivaHandler {
 
     private releaseSession(): void {
         this.adReporter?.destroy();
-        this.verizonAdReporter?.destroy();
+        this.uplynkAdReporter?.destroy();
         this.yospaceAdReporter?.destroy();
         this.adReporter = undefined;
-        this.verizonAdReporter = undefined;
+        this.uplynkAdReporter = undefined;
         this.yospaceAdReporter = undefined;
 
         this.convivaAdAnalytics?.release();

--- a/conviva/src/integration/ads/UplynkAdReporter.ts
+++ b/conviva/src/integration/ads/UplynkAdReporter.ts
@@ -1,21 +1,21 @@
 import type {
     ChromelessPlayer,
-    VerizonMediaAdBeginEvent,
-    VerizonMediaAdBreak,
-    VerizonMediaAdBreakBeginEvent,
-    VerizonMediaAddAdBreakEvent,
-    VerizonMediaRemoveAdBreakEvent,
+    UplynkAdBeginEvent,
+    UplynkAdBreak,
+    UplynkAdBreakBeginEvent,
+    UplynkAddAdBreakEvent,
+    UplynkRemoveAdBreakEvent,
     VideoQuality
 } from 'theoplayer';
 import { type AdAnalytics, Constants, type VideoAnalytics } from '@convivainc/conviva-js-coresdk';
-import { calculateVerizonAdBreakInfo, collectPlayerInfo, collectVerizonAdMetadata } from '../../utils/Utils';
+import { calculateUplynkAdBreakInfo, collectPlayerInfo, collectUplynkAdMetadata } from '../../utils/Utils';
 
-export class VerizonAdReporter {
+export class UplynkAdReporter {
     private readonly player: ChromelessPlayer;
     private readonly convivaVideoAnalytics: VideoAnalytics;
     private readonly convivaAdAnalytics: AdAnalytics;
 
-    private currentAdBreak: VerizonMediaAdBreak | undefined;
+    private currentAdBreak: UplynkAdBreak | undefined;
     private adBreakCounter: number = 1;
 
     constructor(player: ChromelessPlayer, videoAnalytics: VideoAnalytics, adAnalytics: AdAnalytics) {
@@ -26,12 +26,12 @@ export class VerizonAdReporter {
         this.addEventListeners();
     }
 
-    private onAdBreakBegin = (event: VerizonMediaAdBreakBeginEvent) => {
+    private onAdBreakBegin = (event: UplynkAdBreakBeginEvent) => {
         this.currentAdBreak = event.adBreak;
         this.convivaVideoAnalytics.reportAdBreakStarted(
             Constants.AdType.SERVER_SIDE,
             Constants.AdPlayer.CONTENT,
-            calculateVerizonAdBreakInfo(this.currentAdBreak, this.adBreakCounter)
+            calculateUplynkAdBreakInfo(this.currentAdBreak, this.adBreakCounter)
         );
         this.adBreakCounter++;
     };
@@ -47,8 +47,8 @@ export class VerizonAdReporter {
         this.currentAdBreak = undefined;
     };
 
-    private onAdBegin = (event: VerizonMediaAdBeginEvent) => {
-        const adMetadata = collectVerizonAdMetadata(event.ad);
+    private onAdBegin = (event: UplynkAdBeginEvent) => {
+        const adMetadata = collectUplynkAdMetadata(event.ad);
         this.convivaAdAnalytics.setAdInfo(adMetadata);
         this.convivaAdAnalytics.reportAdStarted(adMetadata);
         this.convivaAdAnalytics.reportAdMetric(Constants.Playback.PLAYER_STATE, Constants.PlayerState.PLAYING);
@@ -72,7 +72,7 @@ export class VerizonAdReporter {
         this.convivaAdAnalytics.reportAdEnded();
     };
 
-    private onAddAdBreak = (event: VerizonMediaAddAdBreakEvent) => {
+    private onAddAdBreak = (event: UplynkAddAdBreakEvent) => {
         const adBreak = event.adBreak;
         adBreak.addEventListener('adbreakbegin', this.onAdBreakBegin);
         adBreak.addEventListener('adbreakend', this.onAdBreakEnd);
@@ -83,7 +83,7 @@ export class VerizonAdReporter {
         }
     };
 
-    private onRemoveAdBreak = (event: VerizonMediaRemoveAdBreakEvent) => {
+    private onRemoveAdBreak = (event: UplynkRemoveAdBreakEvent) => {
         const adBreak = event.adBreak;
         adBreak.removeEventListener('adbreakbegin', this.onAdBreakBegin);
         adBreak.removeEventListener('adbreakend', this.onAdBreakEnd);
@@ -107,15 +107,15 @@ export class VerizonAdReporter {
     };
 
     private addEventListeners() {
-        this.player.verizonMedia!.ads.adBreaks.addEventListener('addadbreak', this.onAddAdBreak);
-        this.player.verizonMedia!.ads.adBreaks.addEventListener('removeadbreak', this.onRemoveAdBreak);
+        this.player.uplynk!.ads.adBreaks.addEventListener('addadbreak', this.onAddAdBreak);
+        this.player.uplynk!.ads.adBreaks.addEventListener('removeadbreak', this.onRemoveAdBreak);
         this.player.addEventListener('playing', this.onPlaying);
         this.player.addEventListener('pause', this.onPause);
     }
 
     private removeEventListeners() {
-        this.player.verizonMedia!.ads.adBreaks.removeEventListener('addadbreak', this.onAddAdBreak);
-        this.player.verizonMedia!.ads.adBreaks.removeEventListener('removeadbreak', this.onRemoveAdBreak);
+        this.player.uplynk!.ads.adBreaks.removeEventListener('addadbreak', this.onAddAdBreak);
+        this.player.uplynk!.ads.adBreaks.removeEventListener('removeadbreak', this.onRemoveAdBreak);
         this.player.removeEventListener('playing', this.onPlaying);
         this.player.removeEventListener('pause', this.onPause);
     }

--- a/conviva/src/integration/ads/UplynkAdReporter.ts
+++ b/conviva/src/integration/ads/UplynkAdReporter.ts
@@ -107,15 +107,19 @@ export class UplynkAdReporter {
     };
 
     private addEventListeners() {
-        this.player.uplynk!.ads.adBreaks.addEventListener('addadbreak', this.onAddAdBreak);
-        this.player.uplynk!.ads.adBreaks.addEventListener('removeadbreak', this.onRemoveAdBreak);
+        if (this.player.uplynk) {
+            this.player.uplynk.ads.adBreaks.addEventListener('addadbreak', this.onAddAdBreak);
+            this.player.uplynk.ads.adBreaks.addEventListener('removeadbreak', this.onRemoveAdBreak);
+        }
         this.player.addEventListener('playing', this.onPlaying);
         this.player.addEventListener('pause', this.onPause);
     }
 
     private removeEventListeners() {
-        this.player.uplynk!.ads.adBreaks.removeEventListener('addadbreak', this.onAddAdBreak);
-        this.player.uplynk!.ads.adBreaks.removeEventListener('removeadbreak', this.onRemoveAdBreak);
+        if (this.player.uplynk) {
+            this.player.uplynk.ads.adBreaks.removeEventListener('addadbreak', this.onAddAdBreak);
+            this.player.uplynk.ads.adBreaks.removeEventListener('removeadbreak', this.onRemoveAdBreak);
+        }
         this.player.removeEventListener('playing', this.onPlaying);
         this.player.removeEventListener('pause', this.onPause);
     }

--- a/conviva/src/utils/Utils.ts
+++ b/conviva/src/utils/Utils.ts
@@ -13,10 +13,10 @@ import {
     type AdBreak,
     type ChromelessPlayer,
     type GoogleImaAd,
-    type VerizonMediaAd,
-    type VerizonMediaAdBreak,
     version,
-    TypedSource
+    TypedSource,
+    UplynkAdBreak,
+    UplynkAd
 } from 'theoplayer';
 import { ConvivaConfiguration } from '../integration/ConvivaHandler';
 
@@ -62,7 +62,7 @@ export function calculateAdType(adOrBreak: Ad | AdBreak) {
     }
 }
 
-export function calculateVerizonAdBreakInfo(adBreak: VerizonMediaAdBreak, adBreakIndex: number): ConvivaAdBreakInfo {
+export function calculateUplynkAdBreakInfo(adBreak: UplynkAdBreak, adBreakIndex: number): ConvivaAdBreakInfo {
     return {
         [Constants.POD_DURATION]: adBreak.duration!,
         [Constants.POD_INDEX]: adBreakIndex
@@ -154,7 +154,7 @@ export function collectYospaceAdMetadata(player: ChromelessPlayer, ad: AdVert): 
     };
 }
 
-export function collectVerizonAdMetadata(ad: VerizonMediaAd): ConvivaMetadata {
+export function collectUplynkAdMetadata(ad: UplynkAd): ConvivaMetadata {
     const adMetadata: ConvivaMetadata = {
         [Constants.DURATION]: ad.duration as any
     };

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "prettier": "^3.2.4",
         "rimraf": "^5.0.5",
         "rollup": "^4.14.0",
-        "theoplayer": "^8.3.0",
+        "theoplayer": "^9.8.2",
         "ts-jest": "^29.1.2",
         "ts-node": "^10.9.2",
         "tslib": "^2.6.2",
@@ -70,15 +70,15 @@
     },
     "conviva": {
       "name": "@theoplayer/conviva-connector-web",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "license": "MIT",
       "devDependencies": {
-        "@convivainc/conviva-js-coresdk": "^4.7.4"
+        "@convivainc/conviva-js-coresdk": "^4.8.0"
       },
       "peerDependencies": {
-        "@convivainc/conviva-js-coresdk": "^4.7.4",
-        "@theoplayer/yospace-connector-web": "^2.1.2",
-        "theoplayer": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0"
+        "@convivainc/conviva-js-coresdk": "^4.8.0",
+        "@theoplayer/yospace-connector-web": "^2.6.0",
+        "theoplayer": "^5 || ^6 || ^7 || ^8 || ^9"
       },
       "peerDependenciesMeta": {
         "@theoplayer/yospace-connector-web": {
@@ -1274,7 +1274,9 @@
       }
     },
     "node_modules/@convivainc/conviva-js-coresdk": {
-      "version": "4.7.4",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@convivainc/conviva-js-coresdk/-/conviva-js-coresdk-4.8.0.tgz",
+      "integrity": "sha512-5C0Wn5np2rqtWENIWlvmqsR5XkArZtsnURRpFRrXcXjv1aqYIkccDTtXVURWbw35PGv6uNYTxKxQ3bNnyoqgAw==",
       "dev": true,
       "license": "MIT"
     },
@@ -7880,9 +7882,9 @@
       "license": "MIT"
     },
     "node_modules/theoplayer": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/theoplayer/-/theoplayer-8.3.0.tgz",
-      "integrity": "sha512-KV9cpPQHVv8cvtt88lRCM+u+gXd64PlDmDq7Yqzcgkoy7RXisHqtiTdxnCO7U2zkMLNy4rM8WVnjWKZNrDbC0g==",
+      "version": "9.8.2",
+      "resolved": "https://registry.npmjs.org/theoplayer/-/theoplayer-9.8.2.tgz",
+      "integrity": "sha512-9abvrcjGfQETUt/V5ryl8ZFZVVIfUDneYs81FHXyjYugKXnlP4ug28XR+Ja+PA27hGGm8BMlo3o1KtbtavE6cg==",
       "license": "SEE LICENSE AT https://www.theoplayer.com/terms"
     },
     "node_modules/tmp": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "prettier": "^3.2.4",
     "rimraf": "^5.0.5",
     "rollup": "^4.14.0",
-    "theoplayer": "^8.3.0",
+    "theoplayer": "^9.8.2",
     "ts-jest": "^29.1.2",
     "ts-node": "^10.9.2",
     "tslib": "^2.6.2",


### PR DESCRIPTION
The `verizionMedia` extensions was replaced with `uplynk`. The Conviva connector wasn't aware yet.

Also upgrading to the latest theoplayer & Conviva SDK dependencies (4.8.0)