### PR TITLE
Rework adstart timing for Conviva

### DIFF
--- a/.changeset/happy-dryers-join.md
+++ b/.changeset/happy-dryers-join.md
@@ -1,0 +1,5 @@
+---
+"@theoplayer/conviva-connector-web": minor
+---
+
+Moved the ad start tracking to when the first frame has loaded.

--- a/conviva/src/integration/ads/AdReporter.ts
+++ b/conviva/src/integration/ads/AdReporter.ts
@@ -121,8 +121,8 @@ export class AdReporter {
         this.convivaAdAnalytics.reportAdMetric(Constants.Playback.PLAYER_STATE, Constants.PlayerState.PLAYING);
     };
 
-    // Using onLoadedData based off of Conviva comments in THEOSD-15024 stating ad start should happen when the
-    // first frame of the ad is displayed, regardless of playing status.
+    // NOTE (nils.thingvall@dolby.com, 27/08/2025): Using onLoadedData based off of Conviva comments
+    // stating ad start should happen when the first frame of the ad is displayed, regardless of playing status.
     private readonly onLoadedData = () => {
         if (!this.currentAdBreak || !this.currentAd) {
             return;

--- a/conviva/src/integration/ads/AdReporter.ts
+++ b/conviva/src/integration/ads/AdReporter.ts
@@ -46,7 +46,7 @@ export class AdReporter {
 
     private readonly onAdBreakEnd = () => {
         this.convivaVideoAnalytics.reportAdBreakEnded();
-        this.clearCurrentAd();
+        this.currentAd = undefined;
         this.currentAdBreak = undefined;
     };
 
@@ -91,7 +91,7 @@ export class AdReporter {
         if (currentAd.type !== 'linear') {
             return;
         }
-        this.clearCurrentAd();
+        this.currentAd = undefined;
         this.convivaAdAnalytics.reportAdEnded();
     };
 
@@ -170,10 +170,6 @@ export class AdReporter {
             dispatcher?.removeEventListener('adbuffering', this.onAdBuffering);
             dispatcher?.removeEventListener('aderror', this.onAdError);
         });
-    }
-
-    private clearCurrentAd(): void {
-        this.currentAd = undefined;
     }
 
     private startCurrentAd(): void {

--- a/conviva/src/integration/ads/AdReporter.ts
+++ b/conviva/src/integration/ads/AdReporter.ts
@@ -180,7 +180,6 @@ export class AdReporter {
         if (!this.currentAd) {
             return;
         }
-        console.log('### start current ad');
         const adMetadata = collectAdMetadata(this.currentAd);
         this.convivaAdAnalytics.reportAdStarted(adMetadata);
         this.convivaAdAnalytics.reportAdMetric(

--- a/conviva/src/integration/ads/AdReporter.ts
+++ b/conviva/src/integration/ads/AdReporter.ts
@@ -160,6 +160,7 @@ export class AdReporter {
     private removeEventListeners(): void {
         this.player.removeEventListener('playing', this.onPlaying);
         this.player.removeEventListener('pause', this.onPause);
+        this.player.removeEventListener('loadeddata', this.onLoadedData);
         [this.player.ads, this.player.ads?.convivaAdEventsExtension].forEach((dispatcher) => {
             dispatcher?.removeEventListener('adbreakbegin', this.onAdBreakBegin);
             dispatcher?.removeEventListener('adbreakend', this.onAdBreakEnd);


### PR DESCRIPTION
In order to follow the [timing recommendations from Conviva](https://pulse.conviva.com/learning-center/content/sensor_developer_center/sensor_integration/javascript/javascript_stream_sensor.htm#APIDiagramsforCustomAdIntegration), I separated the adstart tracking out into a listener for loaddata. This fits the ask from Conviva to dispatch the adstart when the first frame is shown, regardless of whether the ad is actually playing. This also introduces a separation between adloaded and adstart. 
<img width="1701" height="1093" alt="image" src="https://github.com/user-attachments/assets/4b8bcb33-8d87-4fd6-8dc0-27b22dcf0c3a" />
