### PR TITLE
Add more reporting to Conviva

### DIFF
--- a/.changeset/social-bars-trade.md
+++ b/.changeset/social-bars-trade.md
@@ -1,0 +1,5 @@
+---
+'@theoplayer/conviva-connector-web': minor
+---
+
+Added reporting of `encoding_type` (either "DASH", "HLS" or "HESP"), as well as `Constant.defaultResource` and `intentToFallback` reason for THEOlive sources.

--- a/conviva/src/integration/ConvivaHandler.ts
+++ b/conviva/src/integration/ConvivaHandler.ts
@@ -23,6 +23,7 @@ import { AdReporter } from './ads/AdReporter';
 import { YospaceAdReporter } from './ads/YospaceAdReporter';
 import { UplynkAdReporter } from './ads/UplynkAdReporter';
 import { ErrorReportBuilder } from '../utils/ErrorReportBuilder';
+import { THEOliveReporter } from './theolive/THEOliveReporter';
 
 enum CustomConstants {
     ENCODING_TYPE = 'encoding_type'
@@ -45,6 +46,7 @@ export class ConvivaHandler {
     private convivaAdAnalytics: AdAnalytics | undefined;
 
     private adReporter: AdReporter | undefined;
+    private THEOliveReporter: THEOliveReporter | undefined;
     private yospaceAdReporter: YospaceAdReporter | undefined;
     private uplynkAdReporter: UplynkAdReporter | undefined;
 
@@ -102,6 +104,8 @@ export class ConvivaHandler {
                 this.yospaceConnector
             );
         }
+
+        this.THEOliveReporter = new THEOliveReporter(this.player, this.convivaVideoAnalytics);
     }
 
     connect(connector: YospaceConnector): void {
@@ -388,9 +392,11 @@ export class ConvivaHandler {
         this.adReporter?.destroy();
         this.uplynkAdReporter?.destroy();
         this.yospaceAdReporter?.destroy();
+        this.THEOliveReporter?.destroy();
         this.adReporter = undefined;
         this.uplynkAdReporter = undefined;
         this.yospaceAdReporter = undefined;
+        this.THEOliveReporter = undefined;
 
         this.convivaAdAnalytics?.release();
         this.convivaVideoAnalytics?.release();

--- a/conviva/src/integration/theolive/THEOliveReporter.ts
+++ b/conviva/src/integration/theolive/THEOliveReporter.ts
@@ -1,0 +1,40 @@
+import type { ChromelessPlayer, EndpointLoadedEvent, IntentToFallbackEvent } from 'theoplayer';
+import { Constants, type VideoAnalytics } from '@convivainc/conviva-js-coresdk';
+import { flattenErrorObject } from '../../utils/ErrorReportBuilder';
+
+export class THEOliveReporter {
+    private readonly player: ChromelessPlayer;
+    private readonly convivaVideoAnalytics: VideoAnalytics;
+
+    constructor(player: ChromelessPlayer, videoAnalytics: VideoAnalytics) {
+        this.player = player;
+        this.convivaVideoAnalytics = videoAnalytics;
+        this.addEventListeners();
+    }
+
+    private readonly onEndpointLoaded = (event: EndpointLoadedEvent) => {
+        const { endpoint } = event;
+        if (endpoint.cdn) {
+            this.convivaVideoAnalytics.setContentInfo({ [Constants.DEFAULT_RESOURCE]: endpoint.cdn });
+        }
+    };
+
+    private readonly onIntentToFallback = (event: IntentToFallbackEvent) => {
+        const { reason } = event;
+        this.convivaVideoAnalytics?.reportPlaybackEvent('intentToFallback', flattenErrorObject(reason));
+    };
+
+    private addEventListeners(): void {
+        this.player.theoLive?.addEventListener('endpointloaded', this.onEndpointLoaded);
+        this.player.theoLive?.addEventListener('intenttofallback', this.onIntentToFallback);
+    }
+
+    private removeEventListeners(): void {
+        this.player.theoLive?.removeEventListener('endpointloaded', this.onEndpointLoaded);
+        this.player.theoLive?.removeEventListener('intenttofallback', this.onIntentToFallback);
+    }
+
+    destroy(): void {
+        this.removeEventListeners();
+    }
+}

--- a/conviva/src/utils/Utils.ts
+++ b/conviva/src/utils/Utils.ts
@@ -20,6 +20,13 @@ import {
 } from 'theoplayer';
 import { ConvivaConfiguration } from '../integration/ConvivaHandler';
 
+enum EncodingType {
+    DASH = 'application/dash+xml',
+    HLS = 'application/vnd.apple.mpegurl',
+    HLSX = 'application/x-mpegurl',
+    HESP = 'application/vnd.theo.hesp+json'
+}
+
 export function collectDefaultDeviceMetadata(): ConvivaDeviceMetadata {
     // Most device metadata is auto-collected by Conviva
     let category: ConvivaKeys = Constants.DeviceCategory.WEB;
@@ -104,6 +111,19 @@ export function calculateStreamType(player: ChromelessPlayer) {
     if (!Number.isNaN(player.duration)) {
         return isFinite(player.duration) ? Constants.StreamType.VOD : Constants.StreamType.LIVE;
     }
+}
+
+export function calculateEncodingType(source: TypedSource | undefined): string | null {
+    switch (source?.type) {
+        case EncodingType.DASH:
+            return 'DASH';
+        case EncodingType.HLS:
+        case EncodingType.HLSX:
+            return 'HLS';
+        case EncodingType.HESP:
+            return 'HESP';
+    }
+    return null;
 }
 
 export function collectPlayerInfo(): ConvivaPlayerInfo {

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "prettier": "^3.6.2",
         "rimraf": "^6.0.1",
         "rollup": "^4.50.1",
-        "theoplayer": "^9.12.0",
+        "theoplayer": "^10",
         "ts-jest": "^29.4.1",
         "ts-node": "^10.9.2",
         "tslib": "^2.8.1",
@@ -46,7 +46,7 @@
     },
     "adscript": {
       "name": "@theoplayer/adscript-connector-web",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "peerDependencies": {
         "theoplayer": "^7 || ^8 || ^9 || ^10"
@@ -54,7 +54,7 @@
     },
     "cmcd": {
       "name": "@theoplayer/cmcd-connector-web",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "MIT",
       "peerDependencies": {
         "theoplayer": "^5 || ^6 || ^7 || ^8 || ^9 || ^10"
@@ -62,7 +62,7 @@
     },
     "comscore": {
       "name": "@theoplayer/comscore-connector-web",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "MIT",
       "peerDependencies": {
         "theoplayer": "^7 || ^8 || ^9 || ^10"
@@ -70,7 +70,7 @@
     },
     "conviva": {
       "name": "@theoplayer/conviva-connector-web",
-      "version": "2.9.0",
+      "version": "3.0.0",
       "license": "MIT",
       "devDependencies": {
         "@convivainc/conviva-js-coresdk": "^4.8.0"
@@ -88,7 +88,7 @@
     },
     "gemius": {
       "name": "@theoplayer/gemius-connector-web",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "peerDependencies": {
         "theoplayer": "^7 || ^8 || ^9 || ^10"
@@ -96,7 +96,7 @@
     },
     "nielsen": {
       "name": "@theoplayer/nielsen-connector-web",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "MIT",
       "peerDependencies": {
         "theoplayer": "^5 || ^6 || ^7 || ^8 || ^9 || ^10"
@@ -8862,9 +8862,9 @@
       "license": "MIT"
     },
     "node_modules/theoplayer": {
-      "version": "9.12.0",
-      "resolved": "https://registry.npmjs.org/theoplayer/-/theoplayer-9.12.0.tgz",
-      "integrity": "sha512-odRh4oDERE2FRJ1/gzeFx5DtyPP8M3EvZVE1V8Xt0SfL8mBF+Tyo93DqArrQeBCffii27ysMfSFvgw12s/jWOw==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/theoplayer/-/theoplayer-10.0.1.tgz",
+      "integrity": "sha512-4Ek5RaMSmbPbnqDE3MAJNuPoULUpwaEVR4q4hj8reGi6Z40Ib1b6Oa5hpxugqs/orvjTnhLWa3rfW0V0SK9vCQ==",
       "license": "SEE LICENSE AT https://www.theoplayer.com/terms"
     },
     "node_modules/tmpl": {
@@ -9839,7 +9839,7 @@
     },
     "yospace": {
       "name": "@theoplayer/yospace-connector-web",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "license": "MIT",
       "peerDependencies": {
         "theoplayer": "^5 || ^6 || ^7 || ^8.1.0 || ^9 || ^10"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "prettier": "^3.6.2",
     "rimraf": "^6.0.1",
     "rollup": "^4.50.1",
-    "theoplayer": "^9.12.0",
+    "theoplayer": "^10",
     "ts-jest": "^29.4.1",
     "ts-node": "^10.9.2",
     "tslib": "^2.8.1",


### PR DESCRIPTION
Added:
- reporting of the current source's `encoding_type`, either "DASH", "HLS" or "HESP".
- reporting of THEOlive's `intentToFallback` reason.
- reporting of THEOlive's endpoint cdn through `Conviva.defaultResource`.