### PR TITLE
Bump Yospace dependency

### DIFF
--- a/.changeset/early-loops-swim.md
+++ b/.changeset/early-loops-swim.md
@@ -1,0 +1,5 @@
+---
+'@theoplayer/yospace-connector-web': major
+---
+
+Removed `isPlaceholder()` and `isEncoded()` type definitions since they were removed in Yospace Ad Management SDK 3.11.0.

--- a/.changeset/eleven-things-obey.md
+++ b/.changeset/eleven-things-obey.md
@@ -1,0 +1,5 @@
+---
+'@theoplayer/yospace-connector-web': major
+---
+
+Replaced `PlaybackMode` with `SessionMode` for compatibility with Yospace Ad Management SDK 3.10.0+. This change brings the minimum supported Yospace Ad Management SDK version to 3.10.0.

--- a/.changeset/khaki-sloths-jump.md
+++ b/.changeset/khaki-sloths-jump.md
@@ -1,0 +1,5 @@
+---
+'@theoplayer/yospace-connector-web': patch
+---
+
+Fixed an exception when an ad break starts without data during live playback.

--- a/.changeset/ninety-cities-fly.md
+++ b/.changeset/ninety-cities-fly.md
@@ -1,0 +1,5 @@
+---
+'@theoplayer/conviva-connector-web': patch
+---
+
+Added support for `@theoplayer/yospace-connector-web` version 3.

--- a/conviva/package.json
+++ b/conviva/package.json
@@ -46,7 +46,7 @@
   ],
   "peerDependencies": {
     "@convivainc/conviva-js-coresdk": "^4.7.4",
-    "@theoplayer/yospace-connector-web": "^2.1.2",
+    "@theoplayer/yospace-connector-web": "^2.1.2 || ^3",
     "theoplayer": "^8.12.0 || ^9 || ^10 || ^11"
   },
   "peerDependenciesMeta": {

--- a/yospace/README.md
+++ b/yospace/README.md
@@ -7,7 +7,7 @@ In order to use this connector, a [THEOplayer](https://www.npmjs.com/package/the
 
 For setting up a valid Yospace session, the Yospace Ad Management SDK is required. For more information on how to install the Ad Management SDK, please refer to the documentation of [Yospace](https://docs.yospace.com/library/technical/sdks/en/ad-management-sdks-v3/javascript.html). 
 
-**Remark:** This version of the Yospace Connector is compatible with Yospace Ad Management SDK version 3.5.2 or higher. If you still want to use an older Ad Management SDK, please use the connector version 1.4.0.
+**Remark:** This version of the Yospace Connector is compatible with Yospace Ad Management SDK version 3.10.0 or higher. If you still want to use an older Ad Management SDK, please use the connector version 2.8.0 or earlier.
 
 ## Installation
 

--- a/yospace/src/integration/YospaceAdHandler.ts
+++ b/yospace/src/integration/YospaceAdHandler.ts
@@ -123,7 +123,14 @@ export class YospaceAdHandler {
         };
     }
 
-    private onAdvertBreakStart(yospaceAdBreak: YospaceAdBreak) {
+    private onAdvertBreakStart(yospaceAdBreak: YospaceAdBreak | null) {
+        if (yospaceAdBreak === null) {
+            // During live playback, an ad break may be started without any information
+            this.currentAdBreak = this.adIntegrationController?.createAdBreak({
+                timeOffset: this.player.currentTime
+            });
+            return;
+        }
         this.currentAdBreak = this.getOrCreateAdBreak(yospaceAdBreak, true);
     }
 

--- a/yospace/src/integration/YospaceManager.ts
+++ b/yospace/src/integration/YospaceManager.ts
@@ -7,7 +7,7 @@ import type {
 import { getFirstYospaceTypedSource, type YospaceTypedSource, yoSpaceWebSdkIsAvailable } from '../utils/YospaceUtils';
 import { PlayerEvent } from '../yospace/PlayerEvent';
 import {
-    PlaybackMode,
+    SessionMode,
     ResultCode,
     SessionState,
     type YospaceSession,
@@ -298,7 +298,7 @@ export class YospaceManager extends DefaultEventDispatcher<YospaceEventMap> {
 }
 
 function isSessionDVRLive(session: YospaceSession): session is YospaceSessionDVRLive {
-    return session.getPlaybackMode() === PlaybackMode.DVRLIVE;
+    return session.getSessionMode() === SessionMode.DVRLIVE;
 }
 
 function createIntegrationHandler(yospaceManager: YospaceManager): ServerSideAdIntegrationHandler {

--- a/yospace/src/yospace/AdBreak.ts
+++ b/yospace/src/yospace/AdBreak.ts
@@ -26,7 +26,6 @@ export interface Resource {
     getCreativeType(): string;
     getResourceType(): ResourceType;
     getStringData(): string;
-    isEncoded(): boolean;
 }
 
 export interface CreativeEventHandler {
@@ -117,7 +116,6 @@ export interface AdBreak {
     getType(): BreakType;
     getDuration(): number;
     getIdentifier(): string;
-    isPlaceholder(): boolean;
     getPosition(): BreakPosition;
     getRemainingTime(): number;
     getStart(): number;

--- a/yospace/src/yospace/YospaceSessionManager.ts
+++ b/yospace/src/yospace/YospaceSessionManager.ts
@@ -18,7 +18,7 @@ export enum SessionState {
     SHUT_DOWN
 }
 
-export enum PlaybackMode {
+export enum SessionMode {
     LIVE = 0,
     DVRLIVE = 1,
     VOD = 2
@@ -31,7 +31,7 @@ export type YospaceSessionManagerCreator = {
 export interface YospaceSession {
     getAdBreakForAdvert(advert: AdVert): AdBreak | undefined;
 
-    getPlaybackMode(): PlaybackMode;
+    getSessionMode(): SessionMode;
 
     getPlaybackUrl(): string;
 
@@ -53,7 +53,7 @@ export interface YospaceSession {
 }
 
 export interface YospaceSessionDVRLive extends YospaceSession {
-    getPlaybackMode(): PlaybackMode.DVRLIVE;
+    getSessionMode(): SessionMode.DVRLIVE;
 
     getDuration(): number;
 

--- a/yospace/test/pages/main_esm.html
+++ b/yospace/test/pages/main_esm.html
@@ -25,7 +25,7 @@
                 const source = {
                     sources: [
                         {
-                            src: 'https://csm-e-sdk-validation.bln1.yospace.com/csm/extlive/yospace02,hlssample42.m3u8?yo.br=true&yo.av=4',
+                            src: 'https://csm-e-sdk-validation-eb.bln1.yospace.com/csm/extlive/yosdk02,hls-ts-pre.m3u8?yo.av=5',
                             ssai: {
                                 integration: 'yospace'
                             }

--- a/yospace/test/pages/main_umd.html
+++ b/yospace/test/pages/main_umd.html
@@ -25,7 +25,7 @@
                 const source = {
                     sources: [
                         {
-                            src: 'https://csm-e-sdk-validation.bln1.yospace.com/csm/extlive/yospace02,hlssample42.m3u8?yo.br=true&yo.av=4',
+                            src: 'https://csm-e-sdk-validation-eb.bln1.yospace.com/csm/extlive/yosdk02,hls-ts-pre.m3u8?yo.av=5',
                             ssai: {
                                 integration: 'yospace'
                             }


### PR DESCRIPTION
This PR has similar changes to https://github.com/THEOplayer/android-connector/pull/89 for Android to make the Yospace connector compatible with the latest version of the Yospace library. You can find their changelog [here](https://docs.yospace.com/library/technical/sdk-api/ad-management/javascript/previous/release_notes.html).

3 main changes are:
- Replaced `PlaybackMode` with `SessionMode` for compatibility with Yospace Ad Management SDK 3.10.0+. **This change brings the minimum supported Yospace Ad Management SDK version to 3.10.0.**
- Removed `isPlaceholder()` and `isEncoded()` type definitions since they were removed in Yospace Ad Management SDK 3.11.0. -> The alternatives for these are `getCategory()` and `getStatus()` according to their changelog. I haven't included these since their return types are not documented (or I couldn't find them).
- Fixed an exception when an ad break starts without data during live playback. -> This was an existing issue on the connector and doesn't related to the version bump here. There was an exception on console from Yospace library at the beginning of every live stream (regarding `getStart()` being `null`). The change I made basically [aligns the logic to what our Android connector does](https://github.com/THEOplayer/android-connector/blob/149021ae31b236e62f8fe67ef90b89a28db08384/connectors/yospace/src/main/java/com/theoplayer/android/connector/yospace/internal/AdHandler.kt#L77-L84).